### PR TITLE
Update CODEOWNERS to assign ownership to @samanrassam

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @ScilifelabDataCentre/TeamPinga
-
+* @samanrassam


### PR DESCRIPTION
Remove whole of Team Pinga from code reviewers, and add back only Saman. This is to avoid the whole team getting spammed with Renovate PRs and the like.

Could also add reutenauer (Arthur)?