### PR TITLE
CI: Publishing image on master merge. Aligned image name with prod. Bumped Actions versions.

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -3,6 +3,8 @@ name: Publish Docker image
 on:
   release:
     types: [published]
+  push:
+    branches: [master]
 
 permissions:
   contents: read
@@ -18,10 +20,10 @@ jobs:
       packages: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -29,9 +31,9 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository_owner }}/anubis-prod
+          images: ghcr.io/${{ github.repository_owner }}/anubis
           tags: |
             type=sha,format=long
             type=ref,event=branch
@@ -40,7 +42,7 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Build and publish backend
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           file: docker/Dockerfile-prod
           context: .


### PR DESCRIPTION
Publishing the image on master merge. Changed the image name such that it's aligned with the manifests used in production (no -prod suffix). Bumped the versions of Docker actions to current major versions (checkout v3->v6,
login-action v2->v4, metadata-action v4->v6, build-push-action v3->v7).
