### PR TITLE
Removed duplicate image builds on master and release. Fixed Dockerfile ENV warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
                   inputs: requirements.txt
 
     Image-building:
+        if: ${{ github.ref != 'refs/heads/master' && github.ref_type == 'branch' }}
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repo

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -8,9 +8,9 @@ COPY ./anubis /code/anubis
 RUN mkdir /code/site
 
 WORKDIR /code/anubis
-ENV PYTHONPATH /code
+ENV PYTHONPATH=/code
 
-ENV GUNICORN_CMD_ARGS "--bind=0.0.0.0:8000 --workers=1 --thread=4 --worker-class=gthread --forwarded-allow-ips='*' --access-logfile -"
+ENV GUNICORN_CMD_ARGS="--bind=0.0.0.0:8000 --workers=1 --thread=4 --worker-class=gthread --forwarded-allow-ips='*' --access-logfile -"
 CMD ["gunicorn", "main:app"]
 
 VOLUME ["/code/site"]


### PR DESCRIPTION
Follow-up cleanup from #847
In ci.yml image building is now skipped on master pushes and tag pushes since those are handled by publish_container.yml. Unchanged behavior for PR/feature branchs.

In Dockerfile-prod ENV the form was to KEY=VALUE, removing buildkit LegacyKeyValueFormat warnings seen in #847's publish run.
