### PR TITLE
Added CodeQl static analysis workflow for Python

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: "0 10 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+            - language: python
+              build-mode: none
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        queries: security-extended
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Added GitHub SAST scanning with CodeQL. It reads the codebase for vulnerabilities that other steps in the CI doesn't cover (pip-audit for instance). 
Triggers on PR and push to master and weekly cron at Mon 10:00 and findings will appear in Security -> Code scanning on GitHub.

Using query pack: security-extended for Jinja/Flask coverage on first run.

Will add to the master ruleset as a required check after fixing findings from first run.
