### PR TITLE
ci: Configured release-please for clean tags and downstream workflow triggers

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,5 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v5
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
`include-component-in-tag: false` so future tags are `v2.10.1` not `anubis-v2.10.1`. Matches the `v2.9.x` history and `docker/metadata-action`'s semantic version convention.

`token: ${{ secrets.RELEASE_PLEASE_TOKEN }}` (PAT, already added as a repo secret) so downstream workflows trigger on release-please's tags and releases. `GITHUB_TOKEN`-created releases don't fire `release: published` events, which is why `publish_container.yml` didn't run on v2.10.0 and I had to re-publish manually.
