### PR TITLE
fix: waiting for load after grant and call deletion in _cleanup_call

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ def _cleanup_call(settings, page, call_id):
         if delete_btn.is_visible():
             page.once("dialog", lambda d: d.accept())
             delete_btn.click()
+            page.wait_for_load_state("load")
 
     # Proposal
     page.goto(f"{base}/proposals/call/{call_id}")
@@ -62,6 +63,7 @@ def _cleanup_call(settings, page, call_id):
         if delete_btn.is_visible():
             page.once("dialog", lambda d: d.accept())
             delete_btn.click()
+            page.wait_for_load_state("load")
 
     utils.logout(settings, page, settings["ADMIN_USERNAME"])
 


### PR DESCRIPTION
Added a wait after grant and call deletion in _cleanup_call to prevent the function returning prematurely before the navigation triggered by the delete had completed server-side. When the caller then closed the browser context, the delete request could be cut short, leaving the artifact in the DB and causing identifier-collision errors on subsequent test runs.
Only affected running the test on a locally deployed instance.