### PR TITLE
E2e tests for call field configuration for call.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ def _cleanup_call(settings, page, call_id):
         if delete_btn.is_visible():
             page.once("dialog", lambda d: d.accept())
             delete_btn.click()
+            page.wait_for_load_state("load")
 
     # Proposal
     page.goto(f"{base}/proposals/call/{call_id}")
@@ -62,6 +63,7 @@ def _cleanup_call(settings, page, call_id):
         if delete_btn.is_visible():
             page.once("dialog", lambda d: d.accept())
             delete_btn.click()
+            page.wait_for_load_state("load")
 
     utils.logout(settings, page, settings["ADMIN_USERNAME"])
 

--- a/tests/test_admin_actions.py
+++ b/tests/test_admin_actions.py
@@ -4,15 +4,47 @@ Forward lifecycle actions (submit, finalize, lock) all have inverse counterparts
 (unsubmit, unfinalize, unlock). These are easy to forget in refactors and
 regressing one leaves users stuck in a terminal state. Each test
 exercises the forward + inverse together to guard against that.
+
+Uses its own call (CI_ACTIONS_CALL) rather than the shared `seeded_call` so the
+read-only session-scoped proposal in test_access_control.py does not block the
+"Create proposal" link these tests need.
 """
 
+from datetime import datetime, timedelta
+
+import pytest
+from conftest import _cleanup_call, _create_call
 from playwright.sync_api import expect
 
 
-def _submit_proposal(settings, seeded_call, user_page, title):
-    "Submit a proposal as user to the seeded call. Returns the proposal URL."
+ACTIONS_CALL_ID = "CI_ACTIONS_CALL"
+
+
+@pytest.fixture(scope="session")
+def actions_call(settings, browser, pre_session_cleanup):
+    "Session-scoped call dedicated to the inverse-action tests, isolated from other test files' state."
+    context = browser.new_context()
+    page = context.new_page()
+    page.set_default_timeout(15_000)
+    _cleanup_call(settings, page, ACTIONS_CALL_ID)
+    context.close()
+
+    now = datetime.now()
+    opens = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
+    closes = (now + timedelta(days=30)).strftime("%Y-%m-%d %H:%M")
+    yield _create_call(browser, settings, ACTIONS_CALL_ID, opens, closes)
+
+    td_context = browser.new_context()
+    td_page = td_context.new_page()
+    td_page.set_default_timeout(15_000)
+    _cleanup_call(settings, td_page, ACTIONS_CALL_ID)
+    td_context.close()
+
+
+def _submit_proposal(settings, call_id, user_page, title):
+    "Submit a proposal as user to the given call. Returns the proposal URL."
     base = settings["BASE_URL"]
-    user_page.goto(f"{base}/call/{seeded_call}")
+    user_page.goto(f"{base}/call/{call_id}")
     user_page.locator("text=Create proposal").click()
     user_page.locator("#_title").fill(title)
     user_page.locator("#project_title").fill("Project title")
@@ -20,12 +52,12 @@ def _submit_proposal(settings, seeded_call, user_page, title):
     return user_page.url
 
 
-def _create_and_finalize_review(settings, seeded_call, admin_page, reviewer_page):
+def _create_and_finalize_review(settings, call_id, admin_page, reviewer_page):
     "Admin creates the review assignment, reviewer fills the score and finalizes. Returns review URL."
     base = settings["BASE_URL"]
     reviewer_username = settings["REVIEWER_USERNAME"]
 
-    admin_page.goto(f"{base}/reviews/call/{seeded_call}/reviewer/{reviewer_username}")
+    admin_page.goto(f"{base}/reviews/call/{call_id}/reviewer/{reviewer_username}")
     admin_page.get_by_role("checkbox", name="Create").check()
     admin_page.get_by_role("button", name="Create checked reviews").click()
 
@@ -63,9 +95,9 @@ def _delete_proposal(admin_page, proposal_url):
     admin_page.wait_for_load_state("load")
 
 
-def test_proposal_unsubmit(settings, seeded_call, user_page, admin_page):
+def test_proposal_unsubmit(settings, actions_call, user_page, admin_page):
     "Admin unsubmits a submitted proposal and user can edit it again."
-    proposal_url = _submit_proposal(settings, seeded_call, user_page, "Proposal for unsubmit test")
+    proposal_url = _submit_proposal(settings, actions_call, user_page, "Proposal for unsubmit test")
 
     try:
         # Admin sees the Unsubmit button on the submitted proposal
@@ -83,12 +115,12 @@ def test_proposal_unsubmit(settings, seeded_call, user_page, admin_page):
         _delete_proposal(admin_page, proposal_url)
 
 
-def test_review_unfinalize(settings, seeded_call, user_page, admin_page, reviewer_page):
+def test_review_unfinalize(settings, actions_call, user_page, admin_page, reviewer_page):
     "Admin unfinalizes a finalized review and reviewer can edit it again."
-    proposal_url = _submit_proposal(settings, seeded_call, user_page, "Proposal for review unfinalize")
+    proposal_url = _submit_proposal(settings, actions_call, user_page, "Proposal for review unfinalize")
 
     try:
-        review_url = _create_and_finalize_review(settings, seeded_call, admin_page, reviewer_page)
+        review_url = _create_and_finalize_review(settings, actions_call, admin_page, reviewer_page)
 
         # Admin unfinalizes the review
         admin_page.goto(review_url)
@@ -101,12 +133,12 @@ def test_review_unfinalize(settings, seeded_call, user_page, admin_page, reviewe
         _delete_proposal(admin_page, proposal_url)
 
 
-def test_decision_unfinalize(settings, seeded_call, user_page, admin_page, reviewer_page):
+def test_decision_unfinalize(settings, actions_call, user_page, admin_page, reviewer_page):
     "Admin unfinalizes a finalized decision and admin can edit it again."
-    proposal_url = _submit_proposal(settings, seeded_call, user_page, "Proposal for decision unfinalize")
+    proposal_url = _submit_proposal(settings, actions_call, user_page, "Proposal for decision unfinalize")
 
     try:
-        _create_and_finalize_review(settings, seeded_call, admin_page, reviewer_page)
+        _create_and_finalize_review(settings, actions_call, admin_page, reviewer_page)
         _create_and_finalize_decision(proposal_url, admin_page)
 
         # Admin unfinalizes the decision, still on the decision page after finalize
@@ -119,13 +151,13 @@ def test_decision_unfinalize(settings, seeded_call, user_page, admin_page, revie
         _delete_proposal(admin_page, proposal_url)
 
 
-def test_grant_lock_unlock(settings, seeded_call, user_page, admin_page, reviewer_page):
+def test_grant_lock_unlock(settings, actions_call, user_page, admin_page, reviewer_page):
     "Admin locks a grant so user cannot edit, then unlocks so user can edit again."
-    proposal_url = _submit_proposal(settings, seeded_call, user_page, "Proposal for grant lock test")
+    proposal_url = _submit_proposal(settings, actions_call, user_page, "Proposal for grant lock test")
     grant_url = None
 
     try:
-        _create_and_finalize_review(settings, seeded_call, admin_page, reviewer_page)
+        _create_and_finalize_review(settings, actions_call, admin_page, reviewer_page)
         _create_and_finalize_decision(proposal_url, admin_page)
 
         # Admin creates the grant dossier from the accepted proposal

--- a/tests/test_admin_actions.py
+++ b/tests/test_admin_actions.py
@@ -1,0 +1,164 @@
+"""End-to-end tests for admin lifecycle inverse actions.
+
+Forward lifecycle actions (submit, finalize, lock) all have inverse counterparts
+(unsubmit, unfinalize, unlock). These are easy to forget in refactors and
+regressing one leaves users stuck in a terminal state. Each test
+exercises the forward + inverse together to guard against that.
+"""
+
+from playwright.sync_api import expect
+
+
+def _submit_proposal(settings, seeded_call, user_page, title):
+    "Submit a proposal as user to the seeded call. Returns the proposal URL."
+    base = settings["BASE_URL"]
+    user_page.goto(f"{base}/call/{seeded_call}")
+    user_page.locator("text=Create proposal").click()
+    user_page.locator("#_title").fill(title)
+    user_page.locator("#project_title").fill("Project title")
+    user_page.locator("text=Save & submit").click()
+    return user_page.url
+
+
+def _create_and_finalize_review(settings, seeded_call, admin_page, reviewer_page):
+    "Admin creates the review assignment, reviewer fills the score and finalizes. Returns review URL."
+    base = settings["BASE_URL"]
+    reviewer_username = settings["REVIEWER_USERNAME"]
+
+    admin_page.goto(f"{base}/reviews/call/{seeded_call}/reviewer/{reviewer_username}")
+    admin_page.get_by_role("checkbox", name="Create").check()
+    admin_page.get_by_role("button", name="Create checked reviews").click()
+
+    reviewer_page.goto(base)
+    reviewer_page.get_by_role("link", name="My reviews").click()
+    reviewer_page.get_by_role("link", name="Review", exact=True).click()
+    review_url = reviewer_page.url
+    reviewer_page.get_by_role("button", name="Edit").click()
+    reviewer_page.get_by_text("No", exact=True).click()
+    reviewer_page.locator('label[for="quality_score_4"]').click()
+    reviewer_page.get_by_role("button", name="Save").click()
+    reviewer_page.get_by_role("button", name="Finalize").click()
+    expect(reviewer_page.locator(".badge-success", has_text="Finalized")).to_be_visible()
+    return review_url
+
+
+def _create_and_finalize_decision(proposal_url, admin_page):
+    "Admin creates a decision, sets verdict to Accepted, and finalizes. Returns decision URL."
+    admin_page.goto(proposal_url)
+    admin_page.get_by_role("button", name="Create decision").click()
+    decision_url = admin_page.url
+    admin_page.get_by_role("button", name="Edit").click()
+    admin_page.get_by_text("Accepted").click()
+    admin_page.get_by_role("button", name="Save").click()
+    admin_page.get_by_role("button", name="Finalize").click()
+    expect(admin_page.locator(".badge-success", has_text="Finalized")).to_be_visible()
+    return decision_url
+
+
+def _delete_proposal(admin_page, proposal_url):
+    "Admin deletes a proposal. Cascades to its reviews and decisions."
+    admin_page.goto(proposal_url)
+    admin_page.once("dialog", lambda d: d.accept())
+    admin_page.get_by_role("button", name="Delete").click()
+    admin_page.wait_for_load_state("load")
+
+
+def test_proposal_unsubmit(settings, seeded_call, user_page, admin_page):
+    "Admin unsubmits a submitted proposal and user can edit it again."
+    proposal_url = _submit_proposal(settings, seeded_call, user_page, "Proposal for unsubmit test")
+
+    try:
+        # Admin sees the Unsubmit button on the submitted proposal
+        admin_page.goto(proposal_url)
+        expect(admin_page.get_by_role("button", name="Unsubmit")).to_be_visible()
+        admin_page.get_by_role("button", name="Unsubmit").click()
+
+        # After unsubmit, the Submit button is back (proposal returned to editable state)
+        expect(admin_page.get_by_role("button", name="Submit")).to_be_visible()
+
+        # User sees their own proposal as editable again
+        user_page.goto(proposal_url)
+        expect(user_page.get_by_role("button", name="Submit")).to_be_visible()
+    finally:
+        _delete_proposal(admin_page, proposal_url)
+
+
+def test_review_unfinalize(settings, seeded_call, user_page, admin_page, reviewer_page):
+    "Admin unfinalizes a finalized review and reviewer can edit it again."
+    proposal_url = _submit_proposal(settings, seeded_call, user_page, "Proposal for review unfinalize")
+
+    try:
+        review_url = _create_and_finalize_review(settings, seeded_call, admin_page, reviewer_page)
+
+        # Admin unfinalizes the review
+        admin_page.goto(review_url)
+        expect(admin_page.get_by_role("button", name="Unfinalize")).to_be_visible()
+        admin_page.get_by_role("button", name="Unfinalize").click()
+
+        # Verify Finalize button is back (review is editable again)
+        expect(admin_page.get_by_role("button", name="Finalize")).to_be_visible()
+    finally:
+        _delete_proposal(admin_page, proposal_url)
+
+
+def test_decision_unfinalize(settings, seeded_call, user_page, admin_page, reviewer_page):
+    "Admin unfinalizes a finalized decision and admin can edit it again."
+    proposal_url = _submit_proposal(settings, seeded_call, user_page, "Proposal for decision unfinalize")
+
+    try:
+        _create_and_finalize_review(settings, seeded_call, admin_page, reviewer_page)
+        _create_and_finalize_decision(proposal_url, admin_page)
+
+        # Admin unfinalizes the decision, still on the decision page after finalize
+        expect(admin_page.get_by_role("button", name="Unfinalize")).to_be_visible()
+        admin_page.get_by_role("button", name="Unfinalize").click()
+
+        # Verify that the Finalize button is back so decision is editable again
+        expect(admin_page.get_by_role("button", name="Finalize")).to_be_visible()
+    finally:
+        _delete_proposal(admin_page, proposal_url)
+
+
+def test_grant_lock_unlock(settings, seeded_call, user_page, admin_page, reviewer_page):
+    "Admin locks a grant so user cannot edit, then unlocks so user can edit again."
+    proposal_url = _submit_proposal(settings, seeded_call, user_page, "Proposal for grant lock test")
+    grant_url = None
+
+    try:
+        _create_and_finalize_review(settings, seeded_call, admin_page, reviewer_page)
+        _create_and_finalize_decision(proposal_url, admin_page)
+
+        # Admin creates the grant dossier from the accepted proposal
+        admin_page.goto(proposal_url)
+        admin_page.get_by_role("button", name="Create grant dossier").click()
+        grant_url = admin_page.url
+
+        # Admin locks the grant
+        admin_page.get_by_role("button", name="Lock").click()
+        expect(admin_page.locator("text=Locked")).to_be_visible()
+
+        # User cannot edit the locked grant
+        user_page.goto(grant_url)
+        expect(user_page.get_by_role("button", name="Edit")).not_to_be_visible()
+
+        # Admin unlocks the grant
+        admin_page.goto(grant_url)
+        admin_page.get_by_role("button", name="Unlock").click()
+        expect(admin_page.locator("text=Unlocked")).to_be_visible()
+
+        # User can edit the grant again
+        user_page.goto(grant_url)
+        expect(user_page.get_by_role("button", name="Edit")).to_be_visible()
+    finally:
+        # Cleanup: unlock the grant if still locked, then delete it before the proposal
+        # since proposal delete does not cascade to grant
+        if grant_url is not None:
+            admin_page.goto(grant_url)
+            unlock_btn = admin_page.get_by_role("button", name="Unlock")
+            if unlock_btn.is_visible():
+                unlock_btn.click()
+                admin_page.wait_for_load_state("load")
+            admin_page.once("dialog", lambda d: d.accept())
+            admin_page.get_by_role("button", name="Delete").click()
+            admin_page.wait_for_load_state("load")
+        _delete_proposal(admin_page, proposal_url)

--- a/tests/test_admin_configuration.py
+++ b/tests/test_admin_configuration.py
@@ -1,0 +1,50 @@
+"""End-to-end tests for admin configuration endpoints in anubis/admin.py."""
+
+from playwright.sync_api import expect
+
+
+def test_site_configuration_edit(settings, admin_page):
+    "Admin changes site name, change renders on home. Original name restored after."
+    base = settings["BASE_URL"]
+    new_name = "Site under e2e test"
+
+    admin_page.goto(f"{base}/admin/site_configuration")
+    original_name = admin_page.locator('input[name="name"]').input_value()
+
+    try:
+        admin_page.locator('input[name="name"]').fill(new_name)
+        admin_page.get_by_role("button", name="Save").click()
+        expect(admin_page).to_have_url(f"{base}/admin/site_configuration")
+
+        # Site name renders as the home page <h1>
+        admin_page.goto(base)
+        expect(admin_page.locator("h1", has_text=new_name)).to_be_visible()
+    finally:
+        # Restore original name regardless of test outcome
+        admin_page.goto(f"{base}/admin/site_configuration")
+        admin_page.locator('input[name="name"]').fill(original_name)
+        admin_page.get_by_role("button", name="Save").click()
+
+
+def test_database_view_admin_only(settings, admin_page, user_page):
+    "Admin can load /admin/database, non-admin user is redirected away."
+    base = settings["BASE_URL"]
+    target = f"{base}/admin/database"
+
+    admin_page.goto(target)
+    expect(admin_page).to_have_url(target)
+
+    user_page.goto(target)
+    expect(user_page).not_to_have_url(target)
+
+
+def test_settings_view_admin_only(settings, admin_page, user_page):
+    "Admin can load /admin/settings, non-admin user is redirected away."
+    base = settings["BASE_URL"]
+    target = f"{base}/admin/settings"
+
+    admin_page.goto(target)
+    expect(admin_page).to_have_url(target)
+
+    user_page.goto(target)
+    expect(user_page).not_to_have_url(target)

--- a/tests/test_call_field_configuration.py
+++ b/tests/test_call_field_configuration.py
@@ -1,0 +1,75 @@
+"""End-to-end tests for call field configuration in anubis/call.py.
+
+Covers the decision and grant field-definition sub-pages
+(/call/<cid>/decision and /call/<cid>/grant). These edit the call's
+schema, so a regression here corrupts the data structures that
+decisions and grants are built from.
+
+Each mutating test adds a uniquely-named field and removes it again in
+a finally block, leaving the session-scoped seeded_call as it was found.
+"""
+
+from playwright.sync_api import expect
+
+
+def _add_line_field(page, base, cid, sub, field_id, title):
+    "Add a required 'line' field on the given call sub-page (decision or grant)."
+    page.goto(f"{base}/call/{cid}/{sub}")
+    page.get_by_role("button", name="Add line field").click()
+    page.locator("#_lineModal input[name='identifier']").fill(field_id)
+    page.locator("#_lineModal input[name='title']").fill(title)
+    page.locator("#_lineModal input[name='required']").check()
+    page.locator("#_lineModal").get_by_role("button", name="Save").click()
+    expect(page).to_have_url(f"{base}/call/{cid}/{sub}")
+
+
+def _delete_field(page, base, cid, sub, field_id):
+    "Delete the field row identified by field_id, accepting the confirm dialog."
+    page.goto(f"{base}/call/{cid}/{sub}")
+    row = page.locator("tr", has_text=field_id)
+    if row.count() == 0:
+        return
+    page.once("dialog", lambda d: d.accept())
+    row.get_by_role("button", name="Delete").click()
+    page.wait_for_load_state("load")
+
+
+def test_decision_field_config(settings, admin_page, seeded_call):
+    "Admin adds a required decision field; it renders in the config table; delete removes it."
+    base = settings["BASE_URL"]
+    cid = seeded_call
+    field_id = "ci_decision_note"
+    try:
+        _add_line_field(admin_page, base, cid, "decision", field_id, "Decision note")
+        admin_page.goto(f"{base}/call/{cid}/decision")
+        expect(admin_page.locator("tr", has_text=field_id)).to_be_visible()
+    finally:
+        _delete_field(admin_page, base, cid, "decision", field_id)
+    expect(admin_page.locator("tr", has_text=field_id)).to_have_count(0)
+
+
+def test_grant_field_config(settings, admin_page, seeded_call):
+    "Admin adds a required grant field; it renders in the config table; delete removes it."
+    base = settings["BASE_URL"]
+    cid = seeded_call
+    field_id = "ci_grant_budget"
+    try:
+        _add_line_field(admin_page, base, cid, "grant", field_id, "Grant budget")
+        admin_page.goto(f"{base}/call/{cid}/grant")
+        expect(admin_page.locator("tr", has_text=field_id)).to_be_visible()
+    finally:
+        _delete_field(admin_page, base, cid, "grant", field_id)
+    expect(admin_page.locator("tr", has_text=field_id)).to_have_count(0)
+
+
+def test_field_config_pages_admin_only(settings, admin_page, user_page, seeded_call):
+    "Admin can load the decision/grant config pages; a non-admin user is denied and redirected away."
+    base = settings["BASE_URL"]
+    cid = seeded_call
+    for sub in ("decision", "grant"):
+        target = f"{base}/call/{cid}/{sub}"
+        admin_page.goto(target)
+        expect(admin_page).to_have_url(target)
+
+        user_page.goto(target)
+        expect(user_page).not_to_have_url(target)

--- a/tests/test_document_io.py
+++ b/tests/test_document_io.py
@@ -1,0 +1,266 @@
+"""End-to-end tests for document field upload + download paths.
+
+These tests confirm the full upload -> storage -> download round-trip works at every level: proposal, review,
+decision, grant.
+"""
+
+import os
+import tempfile
+from datetime import datetime, timedelta
+
+import pytest
+import utils
+from conftest import _cleanup_call
+from playwright.sync_api import expect
+from test_admin_actions import (
+    _create_and_finalize_decision,
+    _create_and_finalize_review,
+    _delete_proposal,
+    _submit_proposal,
+)
+
+
+DOC_CALL_ID = "CI_DOC_IO_CALL"
+
+
+@pytest.fixture(scope="session")
+def doc_io_call(settings, browser, pre_session_cleanup):
+    """Create a call with document fields at every level + the supporting fields
+    needed by the shared lifecycle helpers (project_title proposal field,
+    quality_score review field, reviewer assignment).
+    """
+    base = settings["BASE_URL"]
+    context = browser.new_context()
+    page = context.new_page()
+    page.set_default_timeout(15_000)
+
+    # Remove any stale call left behind by a prior failed run
+    _cleanup_call(settings, page, DOC_CALL_ID)
+
+    utils.login(settings, page, "admin")
+
+    page.get_by_role("button", name="Calls", exact=True).click()
+    page.get_by_role("link", name="Create a new call").click()
+    page.fill('input[name="identifier"]', DOC_CALL_ID)
+    page.fill('input[name="title"]', "Doc IO test call")
+    page.click("#create")
+    assert page.url == f"{base}/call/{DOC_CALL_ID}/edit"
+
+    now = datetime.now()
+    opens = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
+    closes = (now + timedelta(days=30)).strftime("%Y-%m-%d %H:%M")
+    page.get_by_role("textbox", name="Labels Opens").fill(opens)
+    page.get_by_role("textbox", name="Closes").fill(closes)
+    page.get_by_role("button", name="Save").click()
+    assert page.url == f"{base}/call/{DOC_CALL_ID}"
+
+    # Proposal fields: required line (matches the shared _submit_proposal helper)
+    # + optional document
+    page.locator("text=Edit proposal fields").click()
+    assert page.url == f"{base}/call/{DOC_CALL_ID}/proposal"
+    page.get_by_role("button", name="Add line field").click()
+    page.locator("#_lineModal input[name='identifier']").fill("project_title")
+    page.locator("#_lineModal input[name='required']").check()
+    page.locator("#_lineModal").get_by_role("button", name="Save").click()
+    expect(page.get_by_role("rowheader", name="project_title")).to_be_visible()
+    page.get_by_role("button", name="Add document field").click()
+    page.locator("#_documentModal input[name='identifier']").fill("attachment")
+    page.locator("#_documentModal").get_by_role("button", name="Save").click()
+    expect(page.get_by_role("rowheader", name="attachment")).to_be_visible()
+
+    # Review fields: required score (matches _create_and_finalize_review) + optional document
+    page.goto(f"{base}/call/{DOC_CALL_ID}/review")
+    page.get_by_role("button", name="Add score field").click()
+    page.locator("#_score-identifier").fill("quality_score")
+    page.locator("#_score-title").fill("Scientific quality")
+    page.locator("#_score-required").check()
+    page.get_by_role("button", name="Save").click()
+    expect(page.get_by_role("rowheader", name="quality_score")).to_be_visible()
+    page.get_by_role("button", name="Add document field").click()
+    page.locator("#_documentModal input[name='identifier']").fill("attachment")
+    page.locator("#_documentModal").get_by_role("button", name="Save").click()
+    expect(page.get_by_role("rowheader", name="attachment")).to_be_visible()
+
+    # Decision: optional document (verdict is built-in)
+    page.goto(f"{base}/call/{DOC_CALL_ID}/decision")
+    page.get_by_role("button", name="Add document field").click()
+    page.locator("#_documentModal input[name='identifier']").fill("attachment")
+    page.locator("#_documentModal").get_by_role("button", name="Save").click()
+    expect(page.get_by_role("rowheader", name="attachment")).to_be_visible()
+
+    # Grant: optional document
+    page.goto(f"{base}/call/{DOC_CALL_ID}/grant")
+    page.get_by_role("button", name="Add document field").click()
+    page.locator("#_documentModal input[name='identifier']").fill("attachment")
+    page.locator("#_documentModal").get_by_role("button", name="Save").click()
+    expect(page.get_by_role("rowheader", name="attachment")).to_be_visible()
+
+    # Assign reviewer so reviews can be created
+    page.goto(f"{base}/call/{DOC_CALL_ID}/reviewers")
+    page.locator("#reviewer").fill(settings["REVIEWER_USERNAME"])
+    page.get_by_role("button", name="Add", exact=True).click()
+    assert page.get_by_role("link", name=settings["REVIEWER_USERNAME"]).is_visible()
+
+    utils.logout(settings, page, settings["ADMIN_USERNAME"])
+    context.close()
+
+    yield DOC_CALL_ID
+
+    # Teardown
+    td_context = browser.new_context()
+    td_page = td_context.new_page()
+    td_page.set_default_timeout(15_000)
+    _cleanup_call(settings, td_page, DOC_CALL_ID)
+    td_context.close()
+
+
+@pytest.fixture
+def temp_text_file():
+    "Create a temp .txt file with known bytes. Clean up on test exit. Returns (path, content)."
+    content = b"e2e test document content\n"
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+        f.write(content)
+        path = f.name
+    try:
+        yield path, content
+    finally:
+        os.unlink(path)
+
+
+def test_proposal_document_field_upload_download(settings, doc_io_call, user_page, admin_page, temp_text_file):
+    "User uploads a document on a proposal. The same content downloads via /proposal/<pid>/document/<fid>."
+    base = settings["BASE_URL"]
+    tmp_path, file_content = temp_text_file
+    proposal_url = None
+
+    try:
+        # User creates a proposal with the document attached
+        user_page.goto(f"{base}/call/{doc_io_call}")
+        user_page.locator("text=Create proposal").click()
+        user_page.locator("#_title").fill("Proposal with attachment")
+        user_page.locator("#project_title").fill("Project title")
+        user_page.locator('input[type="file"][name="attachment"]').set_input_files(tmp_path)
+        user_page.locator("text=Save & submit").click()
+        proposal_url = user_page.url
+
+        pid = proposal_url.rstrip("/").rsplit("/", 1)[-1]
+        doc_url = f"{base}/proposal/{pid}/document/attachment"
+
+        resp = user_page.context.request.get(doc_url)
+        assert resp.status == 200
+        assert resp.body() == file_content
+        assert "text/plain" in resp.headers["content-type"]
+    finally:
+        if proposal_url is not None:
+            _delete_proposal(admin_page, proposal_url)
+
+
+def test_review_document_field_upload_download(settings, doc_io_call, user_page, admin_page, reviewer_page, temp_text_file):
+    "Reviewer uploads a document on a review, the same content downloads via /review/<iuid>/document/<fid>."
+    base = settings["BASE_URL"]
+    reviewer_username = settings["REVIEWER_USERNAME"]
+    tmp_path, file_content = temp_text_file
+    proposal_url = None
+
+    try:
+        proposal_url = _submit_proposal(settings, doc_io_call, user_page, "Proposal for review doc test")
+
+        # Admin creates the review assignment for the reviewer
+        admin_page.goto(f"{base}/reviews/call/{doc_io_call}/reviewer/{reviewer_username}")
+        admin_page.get_by_role("checkbox", name="Create").check()
+        admin_page.get_by_role("button", name="Create checked reviews").click()
+
+        # Reviewer opens the review, uploads doc + fills required score, saves
+        reviewer_page.goto(base)
+        reviewer_page.get_by_role("link", name="My reviews").click()
+        reviewer_page.get_by_role("link", name="Review", exact=True).click()
+        review_url = reviewer_page.url
+        reviewer_page.get_by_role("button", name="Edit").click()
+        reviewer_page.locator('input[type="file"][name="attachment"]').set_input_files(tmp_path)
+        reviewer_page.get_by_text("No", exact=True).click()
+        reviewer_page.locator('label[for="quality_score_4"]').click()
+        reviewer_page.get_by_role("button", name="Save").click()
+
+        iuid = review_url.rstrip("/").rsplit("/", 1)[-1]
+        doc_url = f"{base}/review/{iuid}/document/attachment"
+
+        resp = reviewer_page.context.request.get(doc_url)
+        assert resp.status == 200
+        assert resp.body() == file_content
+        assert "text/plain" in resp.headers["content-type"]
+    finally:
+        if proposal_url is not None:
+            _delete_proposal(admin_page, proposal_url)
+
+
+def test_decision_document_field_upload_download(settings, doc_io_call, user_page, admin_page, reviewer_page, temp_text_file):
+    "Admin uploads a document on a decision. The same content downloads via /decision/<iuid>/document/<fid>."
+    base = settings["BASE_URL"]
+    tmp_path, file_content = temp_text_file
+    proposal_url = None
+
+    try:
+        proposal_url = _submit_proposal(settings, doc_io_call, user_page, "Proposal for decision doc test")
+        _create_and_finalize_review(settings, doc_io_call, admin_page, reviewer_page)
+
+        # Admin creates a decision with the document attached
+        admin_page.goto(proposal_url)
+        admin_page.get_by_role("button", name="Create decision").click()
+        decision_url = admin_page.url
+        admin_page.get_by_role("button", name="Edit").click()
+        admin_page.locator('input[type="file"][name="attachment"]').set_input_files(tmp_path)
+        admin_page.get_by_text("Accepted").click()
+        admin_page.get_by_role("button", name="Save").click()
+
+        iuid = decision_url.rstrip("/").rsplit("/", 1)[-1]
+        doc_url = f"{base}/decision/{iuid}/document/attachment"
+
+        resp = admin_page.context.request.get(doc_url)
+        assert resp.status == 200
+        assert resp.body() == file_content
+        assert "text/plain" in resp.headers["content-type"]
+    finally:
+        if proposal_url is not None:
+            _delete_proposal(admin_page, proposal_url)
+
+
+def test_grant_document_field_upload_download(settings, doc_io_call, user_page, admin_page, reviewer_page, temp_text_file):
+    "Admin uploads a document on a grant. The same content downloads via /grant/<gid>/document/<fid>."
+    base = settings["BASE_URL"]
+    tmp_path, file_content = temp_text_file
+    proposal_url = None
+    grant_url = None
+
+    try:
+        proposal_url = _submit_proposal(settings, doc_io_call, user_page, "Proposal for grant doc test")
+        _create_and_finalize_review(settings, doc_io_call, admin_page, reviewer_page)
+        _create_and_finalize_decision(proposal_url, admin_page)
+
+        # Admin creates the grant dossier with the document attached
+        admin_page.goto(proposal_url)
+        admin_page.get_by_role("button", name="Create grant dossier").click()
+        grant_url = admin_page.url
+        admin_page.get_by_role("button", name="Edit").click()
+        admin_page.locator('input[type="file"][name="attachment"]').set_input_files(tmp_path)
+        admin_page.get_by_role("button", name="Save").click()
+
+        gid = grant_url.rstrip("/").rsplit("/", 1)[-1]
+        doc_url = f"{base}/grant/{gid}/document/attachment"
+
+        resp = admin_page.context.request.get(doc_url)
+        assert resp.status == 200
+        assert resp.body() == file_content
+        assert "text/plain" in resp.headers["content-type"]
+    finally:
+        # Grants don't cascade from proposal delete - unlock if needed, then delete grant first
+        if grant_url is not None:
+            admin_page.goto(grant_url)
+            unlock_btn = admin_page.get_by_role("button", name="Unlock")
+            if unlock_btn.is_visible():
+                unlock_btn.click()
+                admin_page.wait_for_load_state("load")
+            admin_page.once("dialog", lambda d: d.accept())
+            admin_page.get_by_role("button", name="Delete").click()
+            admin_page.wait_for_load_state("load")
+        if proposal_url is not None:
+            _delete_proposal(admin_page, proposal_url)

--- a/tests/test_staff_views.py
+++ b/tests/test_staff_views.py
@@ -1,0 +1,69 @@
+"""End-to-end tests for staff/admin-gated list views in calls.py and user.py.
+
+These routes guard data that should only be visible to staff or admins (lists
+of unpublished calls, per-call reviews/grants summaries, pending and staff user
+lists). The tests verify the auth gate on each: admin lands on the target URL,
+non-admin user gets redirected away etc.
+"""
+
+from playwright.sync_api import expect
+
+
+def test_calls_unpublished_staff_only(settings, admin_page, user_page):
+    "Admin can load /calls/unpublished, non-admin user is redirected away."
+    base = settings["BASE_URL"]
+    target = f"{base}/calls/unpublished"
+
+    admin_page.goto(target)
+    expect(admin_page).to_have_url(target)
+
+    user_page.goto(target)
+    expect(user_page).not_to_have_url(target)
+
+
+def test_calls_reviews_overview_staff_only(settings, admin_page, user_page):
+    "Admin can load /calls/reviews, non-admin user is redirected away."
+    base = settings["BASE_URL"]
+    target = f"{base}/calls/reviews"
+
+    admin_page.goto(target)
+    expect(admin_page).to_have_url(target)
+
+    user_page.goto(target)
+    expect(user_page).not_to_have_url(target)
+
+
+def test_calls_grants_overview_staff_only(settings, admin_page, user_page):
+    "Admin can load /calls/grants. Non-admin user is redirected away."
+    base = settings["BASE_URL"]
+    target = f"{base}/calls/grants"
+
+    admin_page.goto(target)
+    expect(admin_page).to_have_url(target)
+
+    user_page.goto(target)
+    expect(user_page).not_to_have_url(target)
+
+
+def test_user_pending_list_admin_only(settings, admin_page, user_page):
+    "Admin can load /user/pending. Non-admin user is redirected away."
+    base = settings["BASE_URL"]
+    target = f"{base}/user/pending"
+
+    admin_page.goto(target)
+    expect(admin_page).to_have_url(target)
+
+    user_page.goto(target)
+    expect(user_page).not_to_have_url(target)
+
+
+def test_user_staff_list_admin_only(settings, admin_page, user_page):
+    "Admin can load /user/staff. Non-admin user is redirected away."
+    base = settings["BASE_URL"]
+    target = f"{base}/user/staff"
+
+    admin_page.goto(target)
+    expect(admin_page).to_have_url(target)
+
+    user_page.goto(target)
+    expect(user_page).not_to_have_url(target)


### PR DESCRIPTION
Added new end-to-end tests for cal field configuration in call.py.

They cover the decision and grant field-definition subpages ( = /call/<call id>/decision and /call/<call id>/grant).

Each test adds a field with a unique name and removes it again.