### PR TITLE
Expanded coverage of e2e tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ body. Never assume the page is on any particular URL.
 from datetime import datetime, timedelta
 
 import pytest
+from playwright.sync_api import expect
 import utils
 
 
@@ -15,6 +16,7 @@ SEEDED_CALL_ID = "CI_SEEDED_CALL"
 SEEDED_TRANSITION_CALL_ID = "CI_TRANSITION_CALL_ID"
 CALL_ID = "CI_LIFECYCLE_TEST"
 SEEDED_CLOSED_CALL_ID = "CI_CLOSED_CALL_ID"
+EXPORT_CALL_ID = "CI_EXPORT_CALL"
 
 @pytest.fixture(scope="session")
 def settings():
@@ -186,4 +188,143 @@ def _create_call(browser, settings, call_id, opening_date, closing_date):
     context.close()
 
     return call_id
+
+
+# Lifecycle helpers shared across the state-mutating test modules. Each "forward"
+# action (submit, finalize) lives here so test_admin_actions, test_document_io,
+# the exports and the audit-log tests can reuse one proven implementation.
+
+def _submit_proposal(settings, call_id, user_page, title):
+    "Submit a proposal as user to the given call. Returns the proposal URL."
+    base = settings["BASE_URL"]
+    user_page.goto(f"{base}/call/{call_id}")
+    user_page.locator("text=Create proposal").click()
+    user_page.locator("#_title").fill(title)
+    user_page.locator("#project_title").fill("Project title")
+    user_page.locator("text=Save & submit").click()
+    return user_page.url
+
+
+def _create_and_finalize_review(settings, call_id, admin_page, reviewer_page):
+    "Admin creates the review assignment, reviewer fills the score and finalizes. Returns review URL."
+    base = settings["BASE_URL"]
+    reviewer_username = settings["REVIEWER_USERNAME"]
+
+    admin_page.goto(f"{base}/reviews/call/{call_id}/reviewer/{reviewer_username}")
+    admin_page.get_by_role("checkbox", name="Create").check()
+    admin_page.get_by_role("button", name="Create checked reviews").click()
+
+    reviewer_page.goto(base)
+    reviewer_page.get_by_role("link", name="My reviews").click()
+    reviewer_page.get_by_role("link", name="Review", exact=True).click()
+    review_url = reviewer_page.url
+    reviewer_page.get_by_role("button", name="Edit").click()
+    reviewer_page.get_by_text("No", exact=True).click()
+    reviewer_page.locator('label[for="quality_score_4"]').click()
+    reviewer_page.get_by_role("button", name="Save").click()
+    reviewer_page.get_by_role("button", name="Finalize").click()
+    expect(reviewer_page.locator(".badge-success", has_text="Finalized")).to_be_visible()
+    return review_url
+
+
+def _create_and_finalize_decision(proposal_url, admin_page):
+    "Admin creates a decision, sets verdict to Accepted, and finalizes. Returns decision URL."
+    admin_page.goto(proposal_url)
+    admin_page.get_by_role("button", name="Create decision").click()
+    decision_url = admin_page.url
+    admin_page.get_by_role("button", name="Edit").click()
+    admin_page.get_by_text("Accepted").click()
+    admin_page.get_by_role("button", name="Save").click()
+    admin_page.get_by_role("button", name="Finalize").click()
+    expect(admin_page.locator(".badge-success", has_text="Finalized")).to_be_visible()
+    return decision_url
+
+
+def _delete_proposal(admin_page, proposal_url):
+    "Admin deletes a proposal. Cascades to its reviews and decisions."
+    admin_page.goto(proposal_url)
+    admin_page.once("dialog", lambda d: d.accept())
+    admin_page.get_by_role("button", name="Delete").click()
+    admin_page.wait_for_load_state("load")
+
+
+@pytest.fixture(scope="session")
+def populated_call(settings, browser, admin_page, user_page, pre_session_cleanup):
+    """Create an isolated call carried through the full lifecycle: one submitted
+    proposal, one finalized review, one finalized (accepted) decision, and a
+    grant dossier. Yields a dict of identifiers for the export and audit-log
+    tests to build download URLs from.
+
+    The review is created for the admin user, who is added as a reviewer here,
+    not for the shared reviewer user. A finalized review still appears in the
+    reviewer's list, so a persistent review for the shared reviewer would leave
+    them with reviews in more than one call and break the "My reviews"
+    navigation that _create_and_finalize_review relies on in other modules.
+    """
+    base = settings["BASE_URL"]
+    admin_username = settings["ADMIN_USERNAME"]
+    cid = EXPORT_CALL_ID
+
+    # Remove any stale call left behind by a prior failed run, then build fresh.
+    context = browser.new_context()
+    page = context.new_page()
+    page.set_default_timeout(15_000)
+    _cleanup_call(settings, page, cid)
+    context.close()
+
+    now = datetime.now()
+    opens = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
+    closes = (now + timedelta(days=30)).strftime("%Y-%m-%d %H:%M")
+    _create_call(browser, settings, cid, opens, closes)
+
+    # Add admin as a reviewer so a review can be created and finalized without
+    # touching the shared reviewer user's "My reviews" list.
+    admin_page.goto(f"{base}/call/{cid}/reviewers")
+    admin_page.locator("#reviewer").fill(admin_username)
+    admin_page.get_by_role("button", name="Add", exact=True).click()
+    expect(admin_page.get_by_role("link", name=admin_username)).to_be_visible()
+
+    # Title must be exactly "Proposal": _cleanup_call finds proposals to delete
+    # with the selector a[title='Proposal'] (the title attribute carries the
+    # proposal title), so any other title would leak the call past teardown.
+    proposal_url = _submit_proposal(settings, cid, user_page, "Proposal")
+    pid = proposal_url.rstrip("/").rsplit("/", 1)[-1]
+
+    # Admin creates its own review for this call, then fills and finalizes it.
+    # Navigation is scoped to this call so it never depends on "My reviews".
+    admin_page.goto(f"{base}/reviews/call/{cid}/reviewer/{admin_username}")
+    admin_page.get_by_role("checkbox", name="Create").check()
+    admin_page.get_by_role("button", name="Create checked reviews").click()
+    admin_page.get_by_role("link", name="Review", exact=True).click()
+    review_url = admin_page.url
+    admin_page.get_by_role("button", name="Edit").click()
+    admin_page.get_by_text("No", exact=True).click()
+    admin_page.locator('label[for="quality_score_4"]').click()
+    admin_page.get_by_role("button", name="Save").click()
+    admin_page.get_by_role("button", name="Finalize").click()
+    expect(admin_page.locator(".badge-success", has_text="Finalized")).to_be_visible()
+    review_iuid = review_url.rstrip("/").rsplit("/", 1)[-1]
+
+    decision_url = _create_and_finalize_decision(proposal_url, admin_page)
+    decision_iuid = decision_url.rstrip("/").rsplit("/", 1)[-1]
+
+    admin_page.goto(proposal_url)
+    admin_page.get_by_role("button", name="Create grant dossier").click()
+    gid = admin_page.url.rstrip("/").rsplit("/", 1)[-1]
+
+    yield {
+        "call": cid,
+        "proposal": pid,
+        "review": review_iuid,
+        "decision": decision_iuid,
+        "grant": gid,
+    }
+
+    # Teardown: _cleanup_call removes grant -> proposals (cascading reviews and
+    # decisions) -> call.
+    td_context = browser.new_context()
+    td_page = td_context.new_page()
+    td_page.set_default_timeout(15_000)
+    _cleanup_call(settings, td_page, cid)
+    td_context.close()
 

--- a/tests/test_admin_actions.py
+++ b/tests/test_admin_actions.py
@@ -1,4 +1,5 @@
-"""End-to-end tests for admin lifecycle inverse actions.
+"""
+End-to-end tests for admin lifecycle inverse actions.
 
 Forward lifecycle actions (submit, finalize, lock) all have inverse counterparts
 (unsubmit, unfinalize, unlock). These are easy to forget in refactors and
@@ -13,7 +14,14 @@ read-only session-scoped proposal in test_access_control.py does not block the
 from datetime import datetime, timedelta
 
 import pytest
-from conftest import _cleanup_call, _create_call
+from conftest import (
+    _cleanup_call,
+    _create_and_finalize_decision,
+    _create_and_finalize_review,
+    _create_call,
+    _delete_proposal,
+    _submit_proposal,
+)
 from playwright.sync_api import expect
 
 
@@ -39,60 +47,6 @@ def actions_call(settings, browser, pre_session_cleanup):
     td_page.set_default_timeout(15_000)
     _cleanup_call(settings, td_page, ACTIONS_CALL_ID)
     td_context.close()
-
-
-def _submit_proposal(settings, call_id, user_page, title):
-    "Submit a proposal as user to the given call. Returns the proposal URL."
-    base = settings["BASE_URL"]
-    user_page.goto(f"{base}/call/{call_id}")
-    user_page.locator("text=Create proposal").click()
-    user_page.locator("#_title").fill(title)
-    user_page.locator("#project_title").fill("Project title")
-    user_page.locator("text=Save & submit").click()
-    return user_page.url
-
-
-def _create_and_finalize_review(settings, call_id, admin_page, reviewer_page):
-    "Admin creates the review assignment, reviewer fills the score and finalizes. Returns review URL."
-    base = settings["BASE_URL"]
-    reviewer_username = settings["REVIEWER_USERNAME"]
-
-    admin_page.goto(f"{base}/reviews/call/{call_id}/reviewer/{reviewer_username}")
-    admin_page.get_by_role("checkbox", name="Create").check()
-    admin_page.get_by_role("button", name="Create checked reviews").click()
-
-    reviewer_page.goto(base)
-    reviewer_page.get_by_role("link", name="My reviews").click()
-    reviewer_page.get_by_role("link", name="Review", exact=True).click()
-    review_url = reviewer_page.url
-    reviewer_page.get_by_role("button", name="Edit").click()
-    reviewer_page.get_by_text("No", exact=True).click()
-    reviewer_page.locator('label[for="quality_score_4"]').click()
-    reviewer_page.get_by_role("button", name="Save").click()
-    reviewer_page.get_by_role("button", name="Finalize").click()
-    expect(reviewer_page.locator(".badge-success", has_text="Finalized")).to_be_visible()
-    return review_url
-
-
-def _create_and_finalize_decision(proposal_url, admin_page):
-    "Admin creates a decision, sets verdict to Accepted, and finalizes. Returns decision URL."
-    admin_page.goto(proposal_url)
-    admin_page.get_by_role("button", name="Create decision").click()
-    decision_url = admin_page.url
-    admin_page.get_by_role("button", name="Edit").click()
-    admin_page.get_by_text("Accepted").click()
-    admin_page.get_by_role("button", name="Save").click()
-    admin_page.get_by_role("button", name="Finalize").click()
-    expect(admin_page.locator(".badge-success", has_text="Finalized")).to_be_visible()
-    return decision_url
-
-
-def _delete_proposal(admin_page, proposal_url):
-    "Admin deletes a proposal. Cascades to its reviews and decisions."
-    admin_page.goto(proposal_url)
-    admin_page.once("dialog", lambda d: d.accept())
-    admin_page.get_by_role("button", name="Delete").click()
-    admin_page.wait_for_load_state("load")
 
 
 def test_proposal_unsubmit(settings, actions_call, user_page, admin_page):

--- a/tests/test_audit_logs.py
+++ b/tests/test_audit_logs.py
@@ -1,0 +1,54 @@
+"""
+End-to-end tests for the audit-log views.
+
+Every major category (call, proposal, review, grant, user) exposes a /logs page
+that renders its change history. Each test loads the page against the fully
+populated call and asserts the heading, the log table, and (for the entities
+that the fixture demonstrably edited) at least one log row.
+"""
+
+from playwright.sync_api import expect
+
+
+def _assert_logs_render(page, base, url, heading, expect_rows=True):
+    "Load a /logs page; assert its heading and the log table render."
+    page.goto(f"{base}{url}")
+    expect(page.get_by_role("heading", name=heading)).to_be_visible()
+    expect(page.get_by_role("columnheader", name="Timestamp")).to_be_visible()
+    if expect_rows:
+        expect(page.locator("table.table-sm tbody tr").first).to_be_visible()
+
+
+def test_call_logs(settings, admin_page, populated_call):
+    "The call has been created and edited, so its log has entries."
+    base = settings["BASE_URL"]
+    cid = populated_call["call"]
+    _assert_logs_render(admin_page, base, f"/call/{cid}/logs", f"Logs for Call {cid}")
+
+
+def test_proposal_logs(settings, admin_page, populated_call):
+    base = settings["BASE_URL"]
+    pid = populated_call["proposal"]
+    _assert_logs_render(admin_page, base, f"/proposal/{pid}/logs", f"Logs for Proposal {pid}")
+
+
+def test_review_logs(settings, admin_page, populated_call):
+    "The review heading is 'Logs for Review of <proposal> by <reviewer>'."
+    base = settings["BASE_URL"]
+    iuid = populated_call["review"]
+    _assert_logs_render(admin_page, base, f"/review/{iuid}/logs", "Logs for Review of")
+
+
+def test_grant_logs(settings, admin_page, populated_call):
+    base = settings["BASE_URL"]
+    gid = populated_call["grant"]
+    _assert_logs_render(admin_page, base, f"/grant/{gid}/logs", f"Logs for Grant {gid}")
+
+
+def test_user_logs(settings, admin_page, populated_call):
+    "Admin's own audit log. The user document may have no edits, so don't require rows."
+    base = settings["BASE_URL"]
+    admin_username = settings["ADMIN_USERNAME"]
+    _assert_logs_render(
+        admin_page, base, f"/user/logs/{admin_username}", f"Logs for User {admin_username}", expect_rows=False
+    )

--- a/tests/test_browser_anonymous.py
+++ b/tests/test_browser_anonymous.py
@@ -35,3 +35,23 @@ def test_documentation(settings, page):
     page.set_default_timeout(15_000)
     page.goto(f"{settings['BASE_URL']}/documentation")
     assert page.url == f"{settings['BASE_URL']}/documentation"
+
+
+def test_status_endpoint(settings, page):
+    "The /status health endpoint returns ok plus the database counts (SMOKE_TESTS #1)."
+    resp = page.request.get(f"{settings['BASE_URL']}/status")
+    assert resp.status == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert "version" in body
+    assert "n_calls" in body
+
+
+def test_sitemap(settings, page):
+    "The /sitemap endpoint returns an XML document that includes the home URL."
+    resp = page.request.get(f"{settings['BASE_URL']}/sitemap")
+    assert resp.status == 200
+    assert "xml" in resp.headers["content-type"]
+    body = resp.text()
+    assert "<url>" in body
+    assert settings["BASE_URL"] in body

--- a/tests/test_document_io.py
+++ b/tests/test_document_io.py
@@ -10,14 +10,14 @@ from datetime import datetime, timedelta
 
 import pytest
 import utils
-from conftest import _cleanup_call
-from playwright.sync_api import expect
-from test_admin_actions import (
+from conftest import (
+    _cleanup_call,
     _create_and_finalize_decision,
     _create_and_finalize_review,
     _delete_proposal,
     _submit_proposal,
 )
+from playwright.sync_api import expect
 
 
 DOC_CALL_ID = "CI_DOC_IO_CALL"

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,6 +1,32 @@
-from utils import get_admin_session
-import requests
+"""End-to-end tests for the download/export endpoints.
+
+Covers the JSON API, the XLSX spreadsheet exports, the ZIP bundles, and the
+DOCX proposal export. Each download test asserts the status, the Content-Type,
+and a non-empty body: enough to catch a format generator silently breaking on a
+library upgrade, which stays invisible until a user clicks download.
+
+The object-level exports (proposal/review/grant) need real documents to export,
+so they use the session-scoped `populated_call` fixture from conftest.
+"""
+
 import json
+
+import requests
+from utils import get_admin_session
+
+# Content-Type substrings sent by the download endpoints (anubis/__init__.py).
+XLSX_MIMETYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+DOCX_MIMETYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+ZIP_MIMETYPE = "application/zip"
+
+
+def _assert_download(session, url, content_type):
+    "Assert the URL returns 200, the expected Content-Type, and a non-empty body."
+    resp = session.get(url)
+    assert resp.status_code == 200
+    assert content_type in resp.headers["Content-Type"]
+    assert len(resp.content) > 0
+
 
 def test_api_calls_open(settings):
     base = settings["BASE_URL"]
@@ -20,19 +46,121 @@ def test_api_calls_closed(settings):
     assert resp.headers["Access-Control-Allow-Origin"] == "*"
 
 
+# Calls-level exports: a workbook of calls, needing only an admin session.
+# seeded_call guarantees at least one call exists in the listings.
+
 def test_calls_open_xlsx(settings):
     base = settings["BASE_URL"]
     session = get_admin_session(settings)
-    resp = session.get(f"{base}/calls/open_xlsx")
-    assert resp.status_code == 200
-    assert "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" in resp.headers["Content-Type"]
-    assert len(resp.content) > 0
+    _assert_download(session, f"{base}/calls/open_xlsx", XLSX_MIMETYPE)
 
+
+def test_calls_closed_xlsx(settings):
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    _assert_download(session, f"{base}/calls/closed_xlsx", XLSX_MIMETYPE)
+
+
+def test_calls_all_xlsx(settings, seeded_call):
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    _assert_download(session, f"{base}/calls/all_xlsx", XLSX_MIMETYPE)
+
+
+def test_calls_owner_xlsx(settings, seeded_call):
+    "The seeded calls are created by admin, so admin is their owner."
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    url = f"{base}/calls/owner/{settings['ADMIN_USERNAME']}.xlsx"
+    _assert_download(session, url, XLSX_MIMETYPE)
+
+
+def test_calls_unpublished_xlsx(settings, seeded_call):
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    _assert_download(session, f"{base}/calls/unpublished.xlsx", XLSX_MIMETYPE)
+
+
+def test_calls_reviews_xlsx(settings, populated_call):
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    _assert_download(session, f"{base}/calls/reviews_xlsx", XLSX_MIMETYPE)
+
+
+def test_calls_grants_xlsx(settings, populated_call):
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    _assert_download(session, f"{base}/calls/grants_xlsx", XLSX_MIMETYPE)
+
+
+# Object-level exports: export a specific call/proposal/review/grant, so they
+# need the fully populated call (admin is its reviewer; see the fixture).
 
 def test_call_zip(settings, seeded_call):
     base = settings["BASE_URL"]
     session = get_admin_session(settings)
-    resp = session.get(f"{base}/call/{seeded_call}.zip")
-    assert resp.status_code == 200
-    assert "application/zip" in resp.headers["Content-Type"]
-    assert len(resp.content) > 0
+    _assert_download(session, f"{base}/call/{seeded_call}.zip", ZIP_MIMETYPE)
+
+
+def test_proposal_docx(settings, populated_call):
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    _assert_download(session, f"{base}/proposal/{populated_call['proposal']}.docx", DOCX_MIMETYPE)
+
+
+def test_proposal_xlsx(settings, populated_call):
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    _assert_download(session, f"{base}/proposal/{populated_call['proposal']}.xlsx", XLSX_MIMETYPE)
+
+
+def test_proposals_call_xlsx(settings, populated_call):
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    _assert_download(session, f"{base}/proposals/call/{populated_call['call']}.xlsx", XLSX_MIMETYPE)
+
+
+def test_reviews_call_xlsx(settings, populated_call):
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    _assert_download(session, f"{base}/reviews/call/{populated_call['call']}.xlsx", XLSX_MIMETYPE)
+
+
+def test_reviews_call_reviewer_xlsx(settings, populated_call):
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    reviewer = settings["ADMIN_USERNAME"]
+    url = f"{base}/reviews/call/{populated_call['call']}/reviewer/{reviewer}.xlsx"
+    _assert_download(session, url, XLSX_MIMETYPE)
+
+
+def test_reviews_call_reviewer_zip(settings, populated_call):
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    reviewer = settings["ADMIN_USERNAME"]
+    url = f"{base}/reviews/call/{populated_call['call']}/reviewer/{reviewer}.zip"
+    _assert_download(session, url, ZIP_MIMETYPE)
+
+
+def test_reviews_proposal_xlsx(settings, populated_call):
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    _assert_download(session, f"{base}/reviews/proposal/{populated_call['proposal']}.xlsx", XLSX_MIMETYPE)
+
+
+def test_grant_zip(settings, populated_call):
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    _assert_download(session, f"{base}/grant/{populated_call['grant']}.zip", ZIP_MIMETYPE)
+
+
+def test_grants_call_xlsx(settings, populated_call):
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    _assert_download(session, f"{base}/grants/call/{populated_call['call']}.xlsx", XLSX_MIMETYPE)
+
+
+def test_grants_call_zip(settings, populated_call):
+    base = settings["BASE_URL"]
+    session = get_admin_session(settings)
+    _assert_download(session, f"{base}/grants/call/{populated_call['call']}.zip", ZIP_MIMETYPE)


### PR DESCRIPTION
Expanded the coverage of e2e tests.

Added additional tests in:
tests_exports.py, 16 download-format tests for XLSX/ZIP/DOCX
added test_audit_logs.py: /logs pages render heading, table, and log entries for call/proposal/review/grant/user
new test_browser_anonymous.py to test both /status and /sitemap endpoints
