### PR TITLE
Added e2e tests for proposal ownership transfer

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,6 +190,49 @@ def _create_call(browser, settings, call_id, opening_date, closing_date):
     return call_id
 
 
+@pytest.fixture(scope="session")
+def user2_page(settings, admin_page, browser):
+    "A second regular user (testuser2), registered and logged in. Deleted at session end."
+    user2_username = "testuser2"
+    user2_email = "testuser2@test.com"
+    user2_password = "testuserpass123"
+    base = settings["BASE_URL"]
+
+    # Register user2 and set its password via admin
+    admin_page.get_by_role("button", name="Users", exact=True).click()
+    admin_page.get_by_role("link", name="Register user").click()
+    admin_page.get_by_role("textbox", name="User name").fill(user2_username)
+    admin_page.get_by_role("textbox", name="Email").fill(user2_email)
+    admin_page.get_by_role("button", name="Register").click()
+    admin_page.goto(f"{base}/user/all")
+    admin_page.get_by_role("link", name="testuser2").click()
+    admin_page.get_by_role("button", name="Set password", exact=True).click()
+    admin_page.get_by_role("textbox", name="Password").click()
+    admin_page.get_by_role("textbox", name="Password").fill(user2_password)
+    admin_page.get_by_role("button", name="Set password").click()
+
+    # Log in as user2 in its own context
+    context = browser.new_context()
+    page = context.new_page()
+    page.set_default_timeout(15_000)
+    page.goto(base)
+    page.click("text=Login")
+    page.fill('input[name="username"]', user2_username)
+    page.fill('input[name="password"]', user2_password)
+    page.click("id=login")
+    assert page.url.rstrip("/") == base
+
+    yield page
+
+    # Teardown: delete user2
+    context.close()
+    admin_page.get_by_role("button", name="Users", exact=True).click()
+    admin_page.get_by_role("link", name="All users").click()
+    admin_page.get_by_role("link", name=user2_username).click()
+    admin_page.once("dialog", lambda dialog: dialog.accept())
+    admin_page.get_by_role("button", name="Delete").click()
+
+
 # Lifecycle helpers shared across the state-mutating test modules. Each "forward"
 # action (submit, finalize) lives here so test_admin_actions, test_document_io,
 # the exports and the audit-log tests can reuse one proven implementation.

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -3,7 +3,6 @@ Testing access control for admin, user, reviewer and non-user.
 """
 
 import pytest
-from playwright.sync_api import Browser
 from conftest import _create_call, _cleanup_call, SEEDED_CLOSED_CALL_ID
 
 
@@ -20,48 +19,6 @@ def submitted_proposal(settings, seeded_call, user_page):
     user_page.locator("text=Save & submit").click()
 
     yield user_page.url
-
-@pytest.fixture(scope="session")
-def user2_page(settings, admin_page, browser: Browser):
-
-    user2_username = "testuser2"
-    user2_email = "testuser2@test.com"
-    user2_password = "testuserpass123"
-    base = settings["BASE_URL"]
-
-    # Register user2 and set password via admin
-    admin_page.get_by_role("button", name="Users", exact=True).click()
-    admin_page.get_by_role("link", name="Register user").click()
-    admin_page.get_by_role("textbox", name="User name").fill(user2_username)
-    admin_page.get_by_role("textbox", name="Email").fill(user2_email)
-    admin_page.get_by_role("button", name="Register").click()
-    admin_page.goto(f"{base}/user/all")
-    admin_page.get_by_role("link", name="testuser2").click()
-    admin_page.get_by_role("button", name="Set password", exact=True).click()
-    admin_page.get_by_role("textbox", name="Password").click()
-    admin_page.get_by_role("textbox", name="Password").fill(user2_password)
-    admin_page.get_by_role("button", name="Set password").click()
-
-    # Log in as user2
-    context = browser.new_context()
-    user2_page = context.new_page()
-    user2_page.set_default_timeout(15_000)
-    user2_page.goto(base)
-    user2_page.click("text=Login")
-    user2_page.fill('input[name="username"]', user2_username)
-    user2_page.fill('input[name="password"]', user2_password)
-    user2_page.click("id=login")
-    assert user2_page.url.rstrip("/") == base
-
-    yield user2_page
-
-    # Teardown: delete user2
-    context.close()
-    admin_page.get_by_role("button", name="Users", exact=True).click()
-    admin_page.get_by_role("link", name="All users").click()
-    admin_page.get_by_role("link", name=user2_username).click()
-    admin_page.once("dialog", lambda dialog: dialog.accept())
-    admin_page.get_by_role("button", name="Delete").click()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_proposal_transfer.py
+++ b/tests/test_proposal_transfer.py
@@ -3,17 +3,49 @@
 Transfer reassigns a proposal to another user; the new owner gains access
 and the previous owner loses it. Only admin/staff/call-owner may transfer.
 There is no regression net for this today, and ownership change is high impact.
+
+These tests use their own call rather than the shared seeded_call: a user may
+have at most one proposal per call, and seeded_call already holds testuser's
+read-only submitted_proposal, which would block creating another here.
 """
+
+from datetime import datetime, timedelta
 
 import pytest
 from playwright.sync_api import expect
-from conftest import _submit_proposal, _delete_proposal
+from conftest import _create_call, _cleanup_call, _submit_proposal, _delete_proposal
+
+TRANSFER_CALL_ID = "CI_TRANSFER_CALL"
+
+
+@pytest.fixture(scope="session")
+def transfer_call(settings, browser):
+    "A dedicated open call for the transfer tests, isolated from seeded_call."
+    now = datetime.now()
+    opens = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
+    closes = (now + timedelta(days=30)).strftime("%Y-%m-%d %H:%M")
+
+    # Clear any call left behind by a prior failed run, then build fresh.
+    context = browser.new_context()
+    page = context.new_page()
+    page.set_default_timeout(15_000)
+    _cleanup_call(settings, page, TRANSFER_CALL_ID)
+    context.close()
+
+    yield _create_call(browser, settings, TRANSFER_CALL_ID, opens, closes)
+
+    # Teardown
+    context = browser.new_context()
+    page = context.new_page()
+    page.set_default_timeout(15_000)
+    _cleanup_call(settings, page, TRANSFER_CALL_ID)
+    context.close()
 
 
 @pytest.fixture
-def transferable_proposal(settings, seeded_call, user_page, admin_page):
-    "A fresh submitted proposal in the seeded call (mutable, function-scoped). Admin deletes it after."
-    url = _submit_proposal(settings, seeded_call, user_page, "Transfer test proposal")
+def transferable_proposal(settings, transfer_call, user_page, admin_page):
+    "A fresh submitted proposal in the dedicated call (mutable, function-scoped). Admin deletes it after."
+    url = _submit_proposal(settings, transfer_call, user_page, "Transfer test proposal")
     yield url
     _delete_proposal(admin_page, url)
 

--- a/tests/test_proposal_transfer.py
+++ b/tests/test_proposal_transfer.py
@@ -1,0 +1,50 @@
+"""End-to-end tests for proposal ownership transfer (anubis/proposal.py).
+
+Transfer reassigns a proposal to another user; the new owner gains access
+and the previous owner loses it. Only admin/staff/call-owner may transfer.
+There is no regression net for this today, and ownership change is high impact.
+"""
+
+import pytest
+from playwright.sync_api import expect
+from conftest import _submit_proposal, _delete_proposal
+
+
+@pytest.fixture
+def transferable_proposal(settings, seeded_call, user_page, admin_page):
+    "A fresh submitted proposal in the seeded call (mutable, function-scoped). Admin deletes it after."
+    url = _submit_proposal(settings, seeded_call, user_page, "Transfer test proposal")
+    yield url
+    _delete_proposal(admin_page, url)
+
+
+def test_transfer_changes_owner(settings, admin_page, user_page, user2_page, transferable_proposal):
+    "Admin transfers a proposal to testuser2; user2 gains view access, the original owner loses it."
+    base = settings["BASE_URL"]
+    pid = transferable_proposal.rstrip("/").split("/")[-1]
+    purl = f"{base}/proposal/{pid}"
+
+    # Admin performs the transfer to testuser2
+    admin_page.goto(f"{purl}/transfer")
+    admin_page.locator("#user").fill("testuser2")
+    admin_page.get_by_role("button", name="Transfer").click()
+    expect(admin_page).to_have_url(purl)
+
+    # New owner can view it
+    user2_page.goto(purl)
+    expect(user2_page).to_have_url(purl)
+
+    # Original owner can no longer view it (redirected away with a denial)
+    user_page.goto(purl)
+    expect(user_page).not_to_have_url(purl)
+    expect(user_page.get_by_text("not allowed to view this proposal")).to_be_visible()
+
+
+def test_transfer_denied_for_submitter(settings, user_page, transferable_proposal):
+    "The submitter (not owner/staff/admin) cannot transfer their own proposal."
+    base = settings["BASE_URL"]
+    pid = transferable_proposal.rstrip("/").split("/")[-1]
+
+    user_page.goto(f"{base}/proposal/{pid}/transfer")
+    expect(user_page).not_to_have_url(f"{base}/proposal/{pid}/transfer")
+    expect(user_page.get_by_text("not allowed to transfer")).to_be_visible()


### PR DESCRIPTION
Added tests/test_proposal_transfer.py covering proposal ownership transfer (anubis/proposal.py): admin transfer reassigns the proposal so the new owner gains view access and the original owner loses it, plus a denial test that a non-owner submitter can't transfer. 
Moved the user2_page fixture from test_access_control.py to conftest.py so both modules share one testuser2, a second copy would double-register the account. Reuses the existing _submit_proposal/_delete_proposal lifecycle helpers.