### PR TITLE
Added e2e tests for decision visibility and review archive/unarchive

### DIFF
--- a/tests/test_decision_visibility.py
+++ b/tests/test_decision_visibility.py
@@ -1,0 +1,75 @@
+"""End-to-end tests for submitter visibility of a finalized decision (anubis/decision.py).
+
+A proposal submitter sees the decision inline on their proposal only when the call
+privilege 'allow_submitter_view_decision' is set and the decision is finalized.
+Staff/admin see it regardless (via the decision link), so these assertions run as
+the submitter (user_page).
+
+Uses a dedicated call: a user may hold only one proposal per call, so this must not
+collide with seeded_call's read-only submitted_proposal.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from playwright.sync_api import expect
+from conftest import _create_call, _cleanup_call, _submit_proposal, _create_and_finalize_decision
+
+DECISION_CALL_ID = "CI_DECISION_VIS_CALL"
+
+
+@pytest.fixture(scope="session")
+def decision_call(settings, browser, admin_page, user_page):
+    "Dedicated call with a submitted proposal and a finalized (Accepted) decision."
+    now = datetime.now()
+    opens = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
+    closes = (now + timedelta(days=30)).strftime("%Y-%m-%d %H:%M")
+
+    # Clear any call left behind by a prior failed run, then build fresh.
+    context = browser.new_context()
+    page = context.new_page()
+    page.set_default_timeout(15_000)
+    _cleanup_call(settings, page, DECISION_CALL_ID)
+    context.close()
+
+    cid = _create_call(browser, settings, DECISION_CALL_ID, opens, closes)
+    # Title must be exactly "Proposal": _cleanup_call finds proposals to delete via
+    # a[title='Proposal'] (the link's title attribute is the proposal title), so any
+    # other title would leak the proposal and block the call's teardown.
+    proposal_url = _submit_proposal(settings, cid, user_page, "Proposal")
+    _create_and_finalize_decision(proposal_url, admin_page)
+
+    yield {"cid": cid, "proposal_url": proposal_url}
+
+    # Teardown
+    context = browser.new_context()
+    page = context.new_page()
+    page.set_default_timeout(15_000)
+    _cleanup_call(settings, page, DECISION_CALL_ID)
+    context.close()
+
+
+def _set_submitter_view_decision(settings, admin_page, cid, enabled):
+    "Toggle the call's allow_submitter_view_decision privilege via the edit form."
+    base = settings["BASE_URL"]
+    admin_page.goto(f"{base}/call/{cid}/edit")
+    box = admin_page.locator("#allow_submitter_view_decision")
+    box.check() if enabled else box.uncheck()
+    admin_page.get_by_role("button", name="Save").click()
+    expect(admin_page).to_have_url(f"{base}/call/{cid}")
+
+
+def test_submitter_sees_decision_when_privilege_set(settings, admin_page, user_page, decision_call):
+    "With the privilege set, the submitter sees the finalized decision on their proposal."
+    _set_submitter_view_decision(settings, admin_page, decision_call["cid"], True)
+
+    user_page.goto(decision_call["proposal_url"])
+    expect(user_page.get_by_text("Accepted", exact=True)).to_be_visible()
+
+
+def test_submitter_blind_when_privilege_unset(settings, admin_page, user_page, decision_call):
+    "Without the privilege, the submitter does not see the decision inline."
+    _set_submitter_view_decision(settings, admin_page, decision_call["cid"], False)
+
+    user_page.goto(decision_call["proposal_url"])
+    expect(user_page.get_by_text("Accepted", exact=True)).to_have_count(0)

--- a/tests/test_review_archive.py
+++ b/tests/test_review_archive.py
@@ -1,0 +1,98 @@
+"""End-to-end tests for archiving/unarchiving finalized reviews (anubis/review.py).
+
+Archiving a finalized review removes it from the active reviews and moves it to
+the call's archived list (so it no longer counts toward ranking); unarchiving
+restores it. Only an admin may archive/unarchive a finalized review.
+
+The review is created for the admin user (added as a reviewer) rather than the
+shared reviewer, so navigation never depends on the reviewer's "My reviews" list.
+Uses a dedicated call (a user may hold only one proposal per call).
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from playwright.sync_api import expect
+from conftest import _create_call, _cleanup_call, _submit_proposal
+
+ARCHIVE_CALL_ID = "CI_REVIEW_ARCHIVE_CALL"
+
+
+@pytest.fixture(scope="session")
+def finalized_review(settings, browser, admin_page, user_page):
+    "Dedicated call with a submitted proposal and one finalized review by the admin."
+    base = settings["BASE_URL"]
+    admin_username = settings["ADMIN_USERNAME"]
+    now = datetime.now()
+    opens = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
+    closes = (now + timedelta(days=30)).strftime("%Y-%m-%d %H:%M")
+
+    # Clear any call left behind by a prior failed run, then build fresh.
+    context = browser.new_context()
+    page = context.new_page()
+    page.set_default_timeout(15_000)
+    _cleanup_call(settings, page, ARCHIVE_CALL_ID)
+    context.close()
+
+    cid = _create_call(browser, settings, ARCHIVE_CALL_ID, opens, closes)
+
+    # Add admin as a reviewer so the review is created and finalized without
+    # touching the shared reviewer's "My reviews" navigation.
+    admin_page.goto(f"{base}/call/{cid}/reviewers")
+    admin_page.locator("#reviewer").fill(admin_username)
+    admin_page.get_by_role("button", name="Add", exact=True).click()
+    expect(admin_page.get_by_role("link", name=admin_username)).to_be_visible()
+
+    # Title must be exactly "Proposal" so _cleanup_call's a[title='Proposal'] finds it.
+    _submit_proposal(settings, cid, user_page, "Proposal")
+
+    admin_page.goto(f"{base}/reviews/call/{cid}/reviewer/{admin_username}")
+    admin_page.get_by_role("checkbox", name="Create").check()
+    admin_page.get_by_role("button", name="Create checked reviews").click()
+    admin_page.get_by_role("link", name="Review", exact=True).click()
+    review_url = admin_page.url
+    admin_page.get_by_role("button", name="Edit").click()
+    admin_page.get_by_text("No", exact=True).click()
+    admin_page.locator('label[for="quality_score_4"]').click()
+    admin_page.get_by_role("button", name="Save").click()
+    admin_page.get_by_role("button", name="Finalize").click()
+    expect(admin_page.locator(".badge-success", has_text="Finalized")).to_be_visible()
+
+    yield {"cid": cid, "review_url": review_url}
+
+    # Teardown
+    context = browser.new_context()
+    page = context.new_page()
+    page.set_default_timeout(15_000)
+    _cleanup_call(settings, page, ARCHIVE_CALL_ID)
+    context.close()
+
+
+def test_archive_unarchive_round_trip(settings, admin_page, finalized_review):
+    "Admin archives a finalized review then unarchives it; the review page reflects each state."
+    review_url = finalized_review["review_url"]
+    # exact=True matters: name="Archive" would otherwise substring-match "Unarchive".
+    archive_btn = admin_page.get_by_role("button", name="Archive", exact=True)
+    unarchive_btn = admin_page.get_by_role("button", name="Unarchive", exact=True)
+
+    # Starts active: only the Archive control is shown.
+    admin_page.goto(review_url)
+    expect(archive_btn).to_be_visible()
+    expect(unarchive_btn).to_have_count(0)
+
+    # Archive it (confirm dialog) -> the review reloads showing Unarchive.
+    admin_page.once("dialog", lambda d: d.accept())
+    archive_btn.click()
+    expect(unarchive_btn).to_be_visible()
+    expect(archive_btn).to_have_count(0)
+
+    # Unarchive restores the active state.
+    unarchive_btn.click()
+    expect(archive_btn).to_be_visible()
+    expect(unarchive_btn).to_have_count(0)
+
+
+def test_archive_denied_for_submitter(settings, user_page, finalized_review):
+    "The proposal submitter cannot view the review, so the archive control is unreachable."
+    user_page.goto(finalized_review["review_url"])
+    expect(user_page).not_to_have_url(finalized_review["review_url"])


### PR DESCRIPTION
Added two new e2e test files covering review and decision output paths:
**In tests/test_decision_visibility.py:** a proposal submitter sees a finalized decision inline only when the call's allow_submitter_view_decision privilege is set. Asserts both the visible and hidden cases from the submiter's own view (staff/admin see it regardless, via the decision link).

**In tests/test_review_archive.py**: admin archives a finalized review then unarchives it, with the review page reflecting each state, plus a denial that the submitter can't view the review, so the archive control is out of reach.
Both use a dedicated call rather than seeded_call, since a user may hold only one proposal per call and seeded_call already holds testuser's submitted_proposal. The review is created for the admin user (added as a reviewer) to avoid depending on the shared reviewer's "My reviews" navigation. Reuses the _submit_proposal / _create_and_finalize_decision helpers from conftest.