### PR TITLE
Refactored isolated-call fixtures onto a shared helper and converted bare is_visible() asserts to expect()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,37 @@ def _cleanup_call(settings, page, call_id):
     utils.logout(settings, page, settings["ADMIN_USERNAME"])
 
 
+def _open_call_dates():
+    "Return (opens, closes) strings for a call that is currently open for ~30 days."
+    now = datetime.now()
+    opens = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
+    closes = (now + timedelta(days=30)).strftime("%Y-%m-%d %H:%M")
+    return opens, closes
+
+
+def _cleanup_call_fresh_context(browser, settings, call_id):
+    "Run _cleanup_call in a throwaway browser context, for fixture setup or teardown."
+    context = browser.new_context()
+    page = context.new_page()
+    page.set_default_timeout(15_000)
+    _cleanup_call(settings, page, call_id)
+    context.close()
+
+
+def _dedicated_call(browser, settings, call_id, opens=None, closes=None):
+    """Generator backing the isolated-call fixtures: remove any stale copy, create
+    the call fresh, yield its identifier, then clean up on teardown. A fixture that
+    only needs the call delegates with `yield from _dedicated_call(...)`. The ones
+    that build extra state (proposals, reviews) call the two helpers above directly.
+    Defaults to an open call. Pass opens/closes for a closed one.
+    """
+    if opens is None or closes is None:
+        opens, closes = _open_call_dates()
+    _cleanup_call_fresh_context(browser, settings, call_id)
+    yield _create_call(browser, settings, call_id, opens, closes)
+    _cleanup_call_fresh_context(browser, settings, call_id)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def pre_session_cleanup(settings, browser):
     "Remove stale test artifacts at session start. Handles cases where teardown did not run (CI kill, hard crash)."
@@ -122,19 +153,7 @@ def seeded_call(settings, browser, pre_session_cleanup):
     the reviewer user assigned, and dates set so it is currently open.
     Yields the call identifier string. Cleaned up after the session ends.
     """
-    call_id = SEEDED_CALL_ID
-    # Set dates so the call is open
-    now = datetime.now()
-    opens = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
-    closes = (now + timedelta(days=30)).strftime("%Y-%m-%d %H:%M")
-    yield _create_call(browser, settings, call_id, opens, closes)
-
-
-    # Teardown
-    td_context = browser.new_context()
-    td_page = td_context.new_page()
-    _cleanup_call(settings, td_page, call_id)
-    td_context.close()
+    yield from _dedicated_call(browser, settings, SEEDED_CALL_ID)
 
 
 def _create_call(browser, settings, call_id, opening_date, closing_date):
@@ -309,15 +328,8 @@ def populated_call(settings, browser, admin_page, user_page, pre_session_cleanup
     cid = EXPORT_CALL_ID
 
     # Remove any stale call left behind by a prior failed run, then build fresh.
-    context = browser.new_context()
-    page = context.new_page()
-    page.set_default_timeout(15_000)
-    _cleanup_call(settings, page, cid)
-    context.close()
-
-    now = datetime.now()
-    opens = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
-    closes = (now + timedelta(days=30)).strftime("%Y-%m-%d %H:%M")
+    _cleanup_call_fresh_context(browser, settings, cid)
+    opens, closes = _open_call_dates()
     _create_call(browser, settings, cid, opens, closes)
 
     # Add admin as a reviewer so a review can be created and finalized without
@@ -365,9 +377,5 @@ def populated_call(settings, browser, admin_page, user_page, pre_session_cleanup
 
     # Teardown: _cleanup_call removes grant -> proposals (cascading reviews and
     # decisions) -> call.
-    td_context = browser.new_context()
-    td_page = td_context.new_page()
-    td_page.set_default_timeout(15_000)
-    _cleanup_call(settings, td_page, cid)
-    td_context.close()
+    _cleanup_call_fresh_context(browser, settings, cid)
 

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -3,7 +3,8 @@ Testing access control for admin, user, reviewer and non-user.
 """
 
 import pytest
-from conftest import _create_call, _cleanup_call, SEEDED_CLOSED_CALL_ID
+from playwright.sync_api import expect
+from conftest import _dedicated_call, SEEDED_CLOSED_CALL_ID
 
 
 @pytest.fixture(scope="session")
@@ -23,16 +24,9 @@ def submitted_proposal(settings, seeded_call, user_page):
 
 @pytest.fixture(scope="session")
 def create_closed_call(settings, browser, pre_session_cleanup):
-    call_id = SEEDED_CLOSED_CALL_ID
-    opens = "1926-12-24 10:00"
-    closes = "1926-12-24 10:01"
-    
-    yield _create_call(browser, settings, call_id, opens, closes)
-
-    td_context = browser.new_context()
-    td_page = td_context.new_page()
-    _cleanup_call(settings, td_page, call_id)
-    td_context.close()
+    yield from _dedicated_call(
+        browser, settings, SEEDED_CLOSED_CALL_ID, opens="1926-12-24 10:00", closes="1926-12-24 10:01"
+    )
 
 
 def test_proposal_access_admin(admin_page, submitted_proposal):
@@ -64,15 +58,15 @@ def test_proposal_access_anonymous(settings, browser, submitted_proposal):
 def test_edit_submitted_proposal(settings, user_page, submitted_proposal):
     user_page.goto(f"{submitted_proposal}/edit")
     assert user_page.url.rstrip("/") == settings["BASE_URL"].rstrip("/")
-    assert user_page.get_by_text("You are not allowed to edit this proposal.").is_visible()
+    expect(user_page.get_by_text("You are not allowed to edit this proposal.")).to_be_visible()
 
 def test_user2_proposal_access(settings, user2_page, submitted_proposal):
     user2_page.goto(f"{submitted_proposal}")
     assert user2_page.url.rstrip("/") == settings["BASE_URL"].rstrip("/")
-    assert user2_page.get_by_text("You are not allowed to view this proposal.").is_visible()
+    expect(user2_page.get_by_text("You are not allowed to view this proposal.")).to_be_visible()
 
 def test_create_proposal_for_closed_call(settings, create_closed_call, user_page):
     base = settings["BASE_URL"]
     user_page.goto(f"{base}/call/{create_closed_call}")
-    assert user_page.get_by_text("Call is closed; a proposal cannot be created.").is_visible()
-    assert not user_page.locator("button").filter(has_text="Create proposal").is_visible()
+    expect(user_page.get_by_text("Call is closed; a proposal cannot be created.")).to_be_visible()
+    expect(user_page.locator("button").filter(has_text="Create proposal")).not_to_be_visible()

--- a/tests/test_admin_actions.py
+++ b/tests/test_admin_actions.py
@@ -11,14 +11,11 @@ read-only session-scoped proposal in test_access_control.py does not block the
 "Create proposal" link these tests need.
 """
 
-from datetime import datetime, timedelta
-
 import pytest
 from conftest import (
-    _cleanup_call,
     _create_and_finalize_decision,
     _create_and_finalize_review,
-    _create_call,
+    _dedicated_call,
     _delete_proposal,
     _submit_proposal,
 )
@@ -31,22 +28,7 @@ ACTIONS_CALL_ID = "CI_ACTIONS_CALL"
 @pytest.fixture(scope="session")
 def actions_call(settings, browser, pre_session_cleanup):
     "Session-scoped call dedicated to the inverse-action tests, isolated from other test files' state."
-    context = browser.new_context()
-    page = context.new_page()
-    page.set_default_timeout(15_000)
-    _cleanup_call(settings, page, ACTIONS_CALL_ID)
-    context.close()
-
-    now = datetime.now()
-    opens = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
-    closes = (now + timedelta(days=30)).strftime("%Y-%m-%d %H:%M")
-    yield _create_call(browser, settings, ACTIONS_CALL_ID, opens, closes)
-
-    td_context = browser.new_context()
-    td_page = td_context.new_page()
-    td_page.set_default_timeout(15_000)
-    _cleanup_call(settings, td_page, ACTIONS_CALL_ID)
-    td_context.close()
+    yield from _dedicated_call(browser, settings, ACTIONS_CALL_ID)
 
 
 def test_proposal_unsubmit(settings, actions_call, user_page, admin_page):

--- a/tests/test_decision_visibility.py
+++ b/tests/test_decision_visibility.py
@@ -9,11 +9,15 @@ Uses a dedicated call: a user may hold only one proposal per call, so this must 
 collide with seeded_call's read-only submitted_proposal.
 """
 
-from datetime import datetime, timedelta
-
 import pytest
 from playwright.sync_api import expect
-from conftest import _create_call, _cleanup_call, _submit_proposal, _create_and_finalize_decision
+from conftest import (
+    _cleanup_call_fresh_context,
+    _create_and_finalize_decision,
+    _create_call,
+    _open_call_dates,
+    _submit_proposal,
+)
 
 DECISION_CALL_ID = "CI_DECISION_VIS_CALL"
 
@@ -21,17 +25,9 @@ DECISION_CALL_ID = "CI_DECISION_VIS_CALL"
 @pytest.fixture(scope="session")
 def decision_call(settings, browser, admin_page, user_page):
     "Dedicated call with a submitted proposal and a finalized (Accepted) decision."
-    now = datetime.now()
-    opens = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
-    closes = (now + timedelta(days=30)).strftime("%Y-%m-%d %H:%M")
-
     # Clear any call left behind by a prior failed run, then build fresh.
-    context = browser.new_context()
-    page = context.new_page()
-    page.set_default_timeout(15_000)
-    _cleanup_call(settings, page, DECISION_CALL_ID)
-    context.close()
-
+    _cleanup_call_fresh_context(browser, settings, DECISION_CALL_ID)
+    opens, closes = _open_call_dates()
     cid = _create_call(browser, settings, DECISION_CALL_ID, opens, closes)
     # Title must be exactly "Proposal": _cleanup_call finds proposals to delete via
     # a[title='Proposal'] (the link's title attribute is the proposal title), so any
@@ -42,11 +38,7 @@ def decision_call(settings, browser, admin_page, user_page):
     yield {"cid": cid, "proposal_url": proposal_url}
 
     # Teardown
-    context = browser.new_context()
-    page = context.new_page()
-    page.set_default_timeout(15_000)
-    _cleanup_call(settings, page, DECISION_CALL_ID)
-    context.close()
+    _cleanup_call_fresh_context(browser, settings, DECISION_CALL_ID)
 
 
 def _set_submitter_view_decision(settings, admin_page, cid, enabled):

--- a/tests/test_document_io.py
+++ b/tests/test_document_io.py
@@ -99,7 +99,7 @@ def doc_io_call(settings, browser, pre_session_cleanup):
     page.goto(f"{base}/call/{DOC_CALL_ID}/reviewers")
     page.locator("#reviewer").fill(settings["REVIEWER_USERNAME"])
     page.get_by_role("button", name="Add", exact=True).click()
-    assert page.get_by_role("link", name=settings["REVIEWER_USERNAME"]).is_visible()
+    expect(page.get_by_role("link", name=settings["REVIEWER_USERNAME"])).to_be_visible()
 
     utils.logout(settings, page, settings["ADMIN_USERNAME"])
     context.close()

--- a/tests/test_proposal_transfer.py
+++ b/tests/test_proposal_transfer.py
@@ -1,6 +1,6 @@
 """End-to-end tests for proposal ownership transfer (anubis/proposal.py).
 
-Transfer reassigns a proposal to another user; the new owner gains access
+Transfer reassigns a proposal to another user. The new owner gains access
 and the previous owner loses it. Only admin/staff/call-owner may transfer.
 There is no regression net for this today, and ownership change is high impact.
 
@@ -9,11 +9,9 @@ have at most one proposal per call, and seeded_call already holds testuser's
 read-only submitted_proposal, which would block creating another here.
 """
 
-from datetime import datetime, timedelta
-
 import pytest
 from playwright.sync_api import expect
-from conftest import _create_call, _cleanup_call, _submit_proposal, _delete_proposal
+from conftest import _dedicated_call, _submit_proposal, _delete_proposal
 
 TRANSFER_CALL_ID = "CI_TRANSFER_CALL"
 
@@ -21,25 +19,7 @@ TRANSFER_CALL_ID = "CI_TRANSFER_CALL"
 @pytest.fixture(scope="session")
 def transfer_call(settings, browser):
     "A dedicated open call for the transfer tests, isolated from seeded_call."
-    now = datetime.now()
-    opens = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
-    closes = (now + timedelta(days=30)).strftime("%Y-%m-%d %H:%M")
-
-    # Clear any call left behind by a prior failed run, then build fresh.
-    context = browser.new_context()
-    page = context.new_page()
-    page.set_default_timeout(15_000)
-    _cleanup_call(settings, page, TRANSFER_CALL_ID)
-    context.close()
-
-    yield _create_call(browser, settings, TRANSFER_CALL_ID, opens, closes)
-
-    # Teardown
-    context = browser.new_context()
-    page = context.new_page()
-    page.set_default_timeout(15_000)
-    _cleanup_call(settings, page, TRANSFER_CALL_ID)
-    context.close()
+    yield from _dedicated_call(browser, settings, TRANSFER_CALL_ID)
 
 
 @pytest.fixture
@@ -51,7 +31,7 @@ def transferable_proposal(settings, transfer_call, user_page, admin_page):
 
 
 def test_transfer_changes_owner(settings, admin_page, user_page, user2_page, transferable_proposal):
-    "Admin transfers a proposal to testuser2; user2 gains view access, the original owner loses it."
+    "Admin transfers a proposal to testuser2, who gains view access while the original owner loses it."
     base = settings["BASE_URL"]
     pid = transferable_proposal.rstrip("/").split("/")[-1]
     purl = f"{base}/proposal/{pid}"

--- a/tests/test_review_archive.py
+++ b/tests/test_review_archive.py
@@ -1,7 +1,7 @@
 """End-to-end tests for archiving/unarchiving finalized reviews (anubis/review.py).
 
 Archiving a finalized review removes it from the active reviews and moves it to
-the call's archived list (so it no longer counts toward ranking); unarchiving
+the call's archived list (so it no longer counts toward ranking). Unarchiving
 restores it. Only an admin may archive/unarchive a finalized review.
 
 The review is created for the admin user (added as a reviewer) rather than the
@@ -9,11 +9,14 @@ shared reviewer, so navigation never depends on the reviewer's "My reviews" list
 Uses a dedicated call (a user may hold only one proposal per call).
 """
 
-from datetime import datetime, timedelta
-
 import pytest
 from playwright.sync_api import expect
-from conftest import _create_call, _cleanup_call, _submit_proposal
+from conftest import (
+    _cleanup_call_fresh_context,
+    _create_call,
+    _open_call_dates,
+    _submit_proposal,
+)
 
 ARCHIVE_CALL_ID = "CI_REVIEW_ARCHIVE_CALL"
 
@@ -23,17 +26,10 @@ def finalized_review(settings, browser, admin_page, user_page):
     "Dedicated call with a submitted proposal and one finalized review by the admin."
     base = settings["BASE_URL"]
     admin_username = settings["ADMIN_USERNAME"]
-    now = datetime.now()
-    opens = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
-    closes = (now + timedelta(days=30)).strftime("%Y-%m-%d %H:%M")
 
     # Clear any call left behind by a prior failed run, then build fresh.
-    context = browser.new_context()
-    page = context.new_page()
-    page.set_default_timeout(15_000)
-    _cleanup_call(settings, page, ARCHIVE_CALL_ID)
-    context.close()
-
+    _cleanup_call_fresh_context(browser, settings, ARCHIVE_CALL_ID)
+    opens, closes = _open_call_dates()
     cid = _create_call(browser, settings, ARCHIVE_CALL_ID, opens, closes)
 
     # Add admin as a reviewer so the review is created and finalized without
@@ -61,15 +57,11 @@ def finalized_review(settings, browser, admin_page, user_page):
     yield {"cid": cid, "review_url": review_url}
 
     # Teardown
-    context = browser.new_context()
-    page = context.new_page()
-    page.set_default_timeout(15_000)
-    _cleanup_call(settings, page, ARCHIVE_CALL_ID)
-    context.close()
+    _cleanup_call_fresh_context(browser, settings, ARCHIVE_CALL_ID)
 
 
 def test_archive_unarchive_round_trip(settings, admin_page, finalized_review):
-    "Admin archives a finalized review then unarchives it; the review page reflects each state."
+    "Admin archives a finalized review then unarchives it. The review page reflects each state."
     review_url = finalized_review["review_url"]
     # exact=True matters: name="Archive" would otherwise substring-match "Unarchive".
     archive_btn = admin_page.get_by_role("button", name="Archive", exact=True)

--- a/tests/test_state_transitions.py
+++ b/tests/test_state_transitions.py
@@ -1,23 +1,13 @@
 import utils
 import pytest
-from conftest import _create_call, _cleanup_call, SEEDED_TRANSITION_CALL_ID
-from datetime import datetime, timedelta
+from playwright.sync_api import expect
+from conftest import _dedicated_call, SEEDED_TRANSITION_CALL_ID
 
 
 @pytest.fixture(scope="session")
 def transition_call(settings, browser, pre_session_cleanup):
     "Open call used exclusively by state transition tests. Cleaned up after the session ends."
-    call_id = SEEDED_TRANSITION_CALL_ID
-    now = datetime.now()
-    opens = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
-    closes = (now + timedelta(days=30)).strftime("%Y-%m-%d %H:%M")
-    
-    yield _create_call(browser, settings, call_id, opens, closes)
-
-    td_context = browser.new_context()
-    td_page = td_context.new_page()
-    _cleanup_call(settings, td_page, call_id)
-    td_context.close()
+    yield from _dedicated_call(browser, settings, SEEDED_TRANSITION_CALL_ID)
 
 @pytest.fixture(autouse=True)
 def pre_test_cleanup(settings, browser, transition_call):
@@ -94,9 +84,9 @@ def test_missing_required_proposal_fields(settings, transition_call, browser):
     page.get_by_role("button", name="Save & submit").click()
 
     assert page.url == f"{base}/proposal/{transition_call}:001"
-    assert page.get_by_text("Submit cannot be done; proposal is incomplete, or call is closed.").is_visible()
-    assert page.get_by_text("Missing value.").is_visible()
-    assert page.get_by_text("A proposal that contains errors cannot be submitted.").is_visible()
+    expect(page.get_by_text("Submit cannot be done; proposal is incomplete, or call is closed.")).to_be_visible()
+    expect(page.get_by_text("Missing value.").first).to_be_visible()
+    expect(page.get_by_text("A proposal that contains errors cannot be submitted.")).to_be_visible()
 
     page.once("dialog", lambda d: d.accept())
     page.get_by_role("button", name="Delete").click()
@@ -110,9 +100,9 @@ def test_missing_review_fields(settings, browser, review_assignment):
     page.set_default_timeout(15_000)
     utils.login(settings, page, "reviewer")
     page.goto(review_assignment)
-    assert not page.locator("button").filter(has_text="Finalize").is_visible()
-    assert page.get_by_text("Missing value.").first.is_visible()
-    assert page.get_by_text("Not finalized").is_visible()
+    expect(page.locator("button").filter(has_text="Finalize")).not_to_be_visible()
+    expect(page.get_by_text("Missing value.").first).to_be_visible()
+    expect(page.get_by_text("Not finalized")).to_be_visible()
 
     context.close()
 
@@ -140,7 +130,7 @@ def test_create_grant_without_finalized_decision(settings, browser, transition_c
     utils.login(settings, page, "admin")
     page.goto(proposal_url)
     page.wait_for_load_state("load")
-    assert not page.locator("button").filter(has_text="Create grant dossier").is_visible()
+    expect(page.locator("button").filter(has_text="Create grant dossier")).not_to_be_visible()
 
     page.once("dialog", lambda d: d.accept())
     page.get_by_role("button", name="Delete").click()
@@ -172,4 +162,4 @@ def test_deletion_of_call_with_proposals(settings, browser, transition_call):
     utils.login(settings, page, "admin")
 
     page.goto(f"{base}/call/{transition_call}")
-    assert not page.get_by_role("button", name="Delete").is_visible()
+    expect(page.get_by_role("button", name="Delete")).not_to_be_visible()

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -1,4 +1,5 @@
 import pytest
+from playwright.sync_api import expect
 
 
 @pytest.fixture(scope="function")
@@ -32,11 +33,11 @@ def new_user(settings, browser, admin_page):
 
 def test_new_user_registration(settings, admin_page, new_user):
     base = settings["BASE_URL"]
-    assert new_user.get_by_text("Message: User account created").is_visible()
+    expect(new_user.get_by_text("Message: User account created")).to_be_visible()
     admin_page.goto(base)
     admin_page.get_by_role("button", name="Users", exact=True).click()
     admin_page.get_by_role("link", name="Pending users").click()
-    assert admin_page.get_by_role("gridcell", name="testnewuser", exact=True).is_visible()
+    expect(admin_page.get_by_role("gridcell", name="testnewuser", exact=True)).to_be_visible()
 
 
 def test_disable_user(settings, admin_page):
@@ -50,9 +51,9 @@ def test_disable_user(settings, admin_page):
         admin_page.get_by_role("textbox", name="Email").fill("testnewuser@test.com")
         admin_page.get_by_role("button", name="Register").click()
         admin_page.get_by_role("link", name=new_username).click()
-        assert admin_page.get_by_role("button", name="Disable").is_visible()
+        expect(admin_page.get_by_role("button", name="Disable")).to_be_visible()
         admin_page.get_by_role("button", name="Disable").click()
-        assert admin_page.get_by_role("button", name="Enable").is_visible()
+        expect(admin_page.get_by_role("button", name="Enable")).to_be_visible()
 
     finally:
         admin_page.goto(f"{base}/user/display/{new_username}")
@@ -78,7 +79,7 @@ def test_profile_editing(settings, browser, admin_page):
         admin_page.get_by_role("button", name="Set password", exact=True).click()
         admin_page.get_by_role("textbox", name="Password").fill(new_password)
         admin_page.get_by_role("button", name="Set password").click()
-        assert admin_page.get_by_text("Message: Password set.").is_visible()
+        expect(admin_page.get_by_text("Message: Password set.")).to_be_visible()
 
         page.goto(base)
         page.get_by_role("button", name="Login").click()
@@ -93,10 +94,10 @@ def test_profile_editing(settings, browser, admin_page):
         page.get_by_text("MSc").click()
         page.get_by_role("button", name="Save").click()
         assert page.url.rstrip("/") == f"{base}/user/display/{new_username}"
-        assert page.get_by_role("cell", name="newgivenname").is_visible()
-        assert page.get_by_role("cell", name="newfamilyname").is_visible()
-        assert page.get_by_role("cell", name="Male").is_visible()
-        assert page.get_by_role("cell", name="MSc").is_visible()
+        expect(page.get_by_role("cell", name="newgivenname")).to_be_visible()
+        expect(page.get_by_role("cell", name="newfamilyname")).to_be_visible()
+        expect(page.get_by_role("cell", name="Male")).to_be_visible()
+        expect(page.get_by_role("cell", name="MSc")).to_be_visible()
     finally:
         admin_page.goto(f"{base}/user/display/{new_username}")
         admin_page.once("dialog", lambda dialog: dialog.accept())


### PR DESCRIPTION
Refactored the e2e fixtures and assertions, with no change to what is tested (full suite still 80 passed, ruff clean).

Two changes:

- Collapsed the duplicated dedicated-call fixture boilerplate (pre-clean, create, teardown, plus the open-date math) onto three shared helpers in `conftest.py`: `_open_call_dates`, `_cleanup_call_fresh_context`, and `_dedicated_call`. `seeded_call`, `create_closed_call`, `transition_call`, `actions_call`, and `transfer_call` now delegate with `yield from _dedicated_call(...)`. The fixtures that build extra state (`populated_call`, `decision_call`, `finalized_review`) use the two smaller helpers for their pre-clean and teardown. `_create_call`/`_cleanup_call` are retained, so other modules importing them are unaffected.
- Converted bare `assert locator.is_visible()` checks in `test_access_control`, `test_state_transitions`, `test_user_management`, and `test_document_io` to `expect(locator).to_be_visible()`. The bare form checks once with no wait and is an intermittent-flake source, whereas `expect()` auto-waits. `test_browser_call_lifecycle` is left untouched as the self-contained smoke test.

